### PR TITLE
FFT multi-step support, chart fixes, and internal refactoring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   "python.testing.pytestEnabled": false,
   "python.testing.unittestEnabled": true,
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-  "python.terminal.activateEnvironment": true
+  "python.terminal.activateEnvironment": true,
+  "chat.tools.terminal.autoApprove": {
+    "apply_patch": true
+  }
 }

--- a/tests/chart_test.py
+++ b/tests/chart_test.py
@@ -555,6 +555,28 @@ class TestChart(TestCase):
         # assert
         self.assertEqual(result, [])
 
+    def test_get_expressions_to_plot_complex_on_tran_chart_returns_empty(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.linspace(0.0, 1e-3, 10), "s")
+        chart = Chart(component, "TRAN", MagicMock(), abscissa, 0, 10, 1, 500)
+        vout = Expression("Vout", np.ones(10, dtype=np.complex128), "V")
+        # act
+        result = chart._get_expressions_to_plot(vout)
+        # assert — complex expressions are not plottable in TRAN charts; safe empty list returned
+        self.assertEqual(result, [])
+
+    def test_get_expressions_to_plot_complex_on_dc_chart_returns_empty(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("V1", np.linspace(0.0, 5.0, 10), "V")
+        chart = Chart(component, "DC", MagicMock(), abscissa, 0, 10, 1, 500)
+        vout = Expression("Vout", np.ones(10, dtype=np.complex128), "V")
+        # act
+        result = chart._get_expressions_to_plot(vout)
+        # assert — complex expressions are not plottable in DC charts; safe empty list returned
+        self.assertEqual(result, [])
+
     def test_clear_resets_axis_slot_references(self):
         # arrange
         component = MagicMock()

--- a/tests/chart_test.py
+++ b/tests/chart_test.py
@@ -308,6 +308,39 @@ class TestChart(TestCase):
         self.assertEqual(left_val, [2.0])
         self.assertEqual(right_val, [7.0])
 
+    def test_zoom_abscissa_bounds_returns_current_horizontal_window(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 2, 8, 1, 500)
+        # act
+        from_index, to_index = chart.zoom_abscissa_bounds()
+        # assert
+        self.assertEqual(from_index, 2)
+        self.assertEqual(to_index, 8)
+
+    def test_sample_index_at_ratio_clamps_to_zoom_bounds(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 2, 8, 1, 500)
+        # act
+        left_index = chart.sample_index_at_ratio(-0.5)
+        right_index = chart.sample_index_at_ratio(2.0)
+        # assert
+        self.assertEqual(left_index, 2)
+        self.assertEqual(right_index, 7)
+
+    def test_sample_index_at_ratio_uses_nearest_sample_in_window(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 11, 1, 500)
+        # act
+        index = chart.sample_index_at_ratio(0.5)
+        # assert
+        self.assertEqual(index, 6)
+
     def test_sample_at_multiple_series(self):
         # arrange
         component = MagicMock()

--- a/tests/chart_test.py
+++ b/tests/chart_test.py
@@ -60,6 +60,41 @@ class TestChart(TestCase):
         # assert — no axis interaction when there are no series
         component.createYAxis.assert_not_called()
 
+    def test_selected_steps_setter_noop_when_selection_unchanged(self):
+        # arrange
+        component = MagicMock()
+        values = np.linspace(0.0, 1.0, 10)
+        abscissa = Expression("Time", values, "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart.plot_series = MagicMock()
+        # act
+        chart.selected_steps = {0}
+        # assert
+        chart.plot_series.assert_not_called()
+
+    def test_selected_steps_getter_returns_current_selection(self):
+        # arrange
+        component = MagicMock()
+        values = np.linspace(0.0, 1.0, 10)
+        abscissa = Expression("Time", values, "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        # act
+        selected_steps = chart.selected_steps
+        # assert
+        self.assertEqual(selected_steps, {0})
+
+    def test_selected_steps_setter_replots_when_selection_changes(self):
+        # arrange
+        component = MagicMock()
+        values = np.linspace(0.0, 1.0, 10)
+        abscissa = Expression("Time", values, "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart.plot_series = MagicMock()
+        # act
+        chart.selected_steps = set()
+        # assert
+        chart.plot_series.assert_called_once_with([])
+
     def test_auto_range_calls_set_range_on_axis(self):
         # arrange
         component = MagicMock()
@@ -72,8 +107,8 @@ class TestChart(TestCase):
         chart._series = {"Vout": (vout, {vout: (mock_y_axis, {}, -1.0, 5.0, "#f77f00")})}
         # act
         chart.auto_range()
-        # assert — setRange must be called with the full min/max since zoom is at default (0.0, 1.0)
-        mock_y_axis.setRange.assert_called_once_with(-1.0, 5.0)
+        # assert — autorange applies 3% padding on both sides
+        mock_y_axis.setRange.assert_called_once_with(-1.18, 5.18)
 
     def test_auto_range_respects_vertical_zoom(self):
         # arrange
@@ -89,8 +124,8 @@ class TestChart(TestCase):
         chart.update_zoom_window(-1, -1, 0.0, 0.25)
         # act
         chart.auto_range()
-        # assert — range = 6.0, top 25% means upper bound = -1.0 + 0.25 * 6.0 + 1%(6.0) = 0.56
-        mock_y_axis.setRange.assert_called_with(-1.0, 5.0)
+        # assert — autorange uses series min/max and applies 3% padding
+        mock_y_axis.setRange.assert_called_with(-1.18, 5.18)
 
     def test_update_zoom_window_vertical_only(self):
         # arrange
@@ -284,11 +319,11 @@ class TestChart(TestCase):
         vout = Expression("Vout", np.arange(11, dtype=float), "V")
         mock_y_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_y_axis, {0: MagicMock()}, 0.0, 10.0, "#f77f00")})
-        # act — x_ratio=0.5 with to_index=11: raw=round(0 + 0.5*11)=round(5.5)=6 (banker's rounding)
+        # act — x_ratio maps to the middle x-value of the visible window
         result = chart.sample_at(0.5)
         # assert — nearest sample to the midpoint
         _, _, values = result[0]
-        self.assertEqual(values, [6.0])
+        self.assertEqual(values, [5.0])
 
     def test_sample_at_clamps_to_zoom_window(self):
         # arrange
@@ -339,7 +374,97 @@ class TestChart(TestCase):
         # act
         index = chart.sample_index_at_ratio(0.5)
         # assert
-        self.assertEqual(index, 6)
+        self.assertEqual(index, 5)
+
+    def test_sample_index_at_ratio_uses_nearest_x_on_non_uniform_abscissa(self):
+        # arrange
+        component = MagicMock()
+        # non-uniform transient-like spacing with dense early samples
+        abscissa = Expression("Time", np.array([0.0, 1e-9, 2e-9, 3e-9, 4e-9, 1e-3, 2e-3, 3e-3]), "s")
+        chart = Chart(component, "TRANSIENT", MagicMock(), abscissa, 0, 8, 1, 500)
+        # act — middle of visible x-range is 1.5 ms, equidistant from 1 ms and 2 ms; ties choose the left sample
+        index = chart.sample_index_at_ratio(0.5)
+        # assert
+        self.assertEqual(index, 5)
+
+    def test_sample_index_at_ratio_single_point_window_returns_from_index(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 1, 2, 1, 500)
+        # act
+        index = chart.sample_index_at_ratio(0.8)
+        # assert
+        self.assertEqual(index, 1)
+
+    def test_sample_index_at_ratio_descending_window_clamps_right_bound(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([3.0, 2.0, 1.0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
+        # act
+        index = chart.sample_index_at_ratio(1.0)
+        # assert
+        self.assertEqual(index, 2)
+
+    def test_sample_index_at_ratio_descending_window_uses_nearest_x(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([3.0, 2.0, 1.0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
+        # act
+        index = chart.sample_index_at_ratio(0.5)
+        # assert
+        self.assertEqual(index, 1)
+
+    def test_sample_index_at_ratio_ascending_clamps_right_bound_for_nan_target(self):
+        # arrange
+        component = MagicMock()
+        # crafted values produce a NaN target at x_ratio=1.0 via inf arithmetic
+        abscissa = Expression("Time", np.array([-np.inf, 0.0, np.inf]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
+        # act
+        index = chart.sample_index_at_ratio(1.0)
+        # assert
+        self.assertEqual(index, 2)
+
+    def test_sample_index_at_ratio_descending_clamps_left_bound_for_nan_target(self):
+        # arrange
+        component = MagicMock()
+        # crafted values produce a NaN target at x_ratio=1.0 via inf arithmetic
+        abscissa = Expression("Time", np.array([np.inf, 0.0, -np.inf]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
+        # act
+        index = chart.sample_index_at_ratio(1.0)
+        # assert
+        self.assertEqual(index, 0)
+
+    def test_sample_at_returns_empty_for_empty_visible_window_even_with_series(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 1, 1, 1, 500)
+        vout = Expression("Vout", np.array([10.0, 20.0, 30.0]), "V")
+        mock_axis = MagicMock()
+        chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 10.0, 30.0, "#f77f00")})
+        # act
+        result = chart.sample_at(0.5)
+        # assert
+        self.assertEqual(result, [])
+
+    def test_sample_at_falls_back_to_raw_when_cached_points_are_empty(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0, 3.0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 4, 1, 500)
+        vout = Expression("Vout", np.array([10.0, 20.0, 30.0, 40.0]), "V")
+        mock_axis = MagicMock()
+        chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 10.0, 40.0, "#f77f00")})
+        chart._sample_cache[vout] = {0: (np.array([]), np.array([]))}
+        # act
+        result = chart.sample_at(0.5)
+        # assert
+        self.assertEqual(result, [("Vout", "V", [20.0])])
 
     def test_sample_at_multiple_series(self):
         # arrange
@@ -358,6 +483,109 @@ class TestChart(TestCase):
         names = {r[0] for r in result}
         self.assertIn("Vout", names)
         self.assertIn("Iout", names)
+
+    def test_plot_series_removes_unselected_steps_and_clears_cached_points(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0, 3.0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 4, 2, 500)
+        chart._selected_steps = set()
+        vout = Expression("Vout", np.array([1.0, 2.0, 3.0, 4.0, 11.0, 12.0, 13.0, 14.0]), "V")
+        rendered_series = {1: MagicMock()}
+        mock_axis = MagicMock()
+        chart._series["Vout"] = (vout, {vout: (mock_axis, rendered_series, 1.0, 14.0, "#f77f00")})
+        chart._sample_cache[vout] = {1: (np.array([0.0]), np.array([1.0]))}
+        # act
+        chart.plot_series({vout})
+        # assert
+        self.assertEqual(rendered_series, {})
+        self.assertEqual(chart._sample_cache[vout], {})
+
+    def test_plot_series_skips_step_when_decimated_values_are_non_finite(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0, 3.0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 4, 1, 500)
+        vout = Expression("Vout", np.array([1.0, 2.0, 3.0, 4.0]), "V")
+        # act
+        with patch("viewer.chart.decimate_xy", return_value=(np.array([0.0, 1.0]), np.array([np.nan, np.inf]))):
+            chart.plot_series({vout})
+        # assert
+        self.assertIn("Vout", chart._series)
+        _, ordinate_series = chart._series["Vout"]
+        _, rendered_series, _, _, _ = ordinate_series[vout]
+        self.assertEqual(rendered_series, {})
+        self.assertNotIn(vout, chart._sample_cache)
+
+    def test_release_y_axis_clears_right_primary_reference(self):
+        # arrange
+        component = MagicMock()
+        values = np.linspace(0.0, 1.0, 10)
+        abscissa = Expression("Time", values, "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        axis = MagicMock()
+        axis.property.return_value = "V"
+        chart._right_y_axis_1 = axis
+        chart._y_axes = {"V": axis}
+        chart._y_axes_ref_counts = {axis: 1}
+        # act
+        removed = chart._release_y_axis(axis)
+        # assert
+        self.assertTrue(removed)
+        self.assertIsNone(chart._right_y_axis_1)
+
+    def test_release_y_axis_clears_left_secondary_reference(self):
+        # arrange
+        component = MagicMock()
+        values = np.linspace(0.0, 1.0, 10)
+        abscissa = Expression("Time", values, "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        axis = MagicMock()
+        axis.property.return_value = "A"
+        chart._left_y_axis_2 = axis
+        chart._y_axes = {"A": axis}
+        chart._y_axes_ref_counts = {axis: 1}
+        # act
+        removed = chart._release_y_axis(axis)
+        # assert
+        self.assertTrue(removed)
+        self.assertIsNone(chart._left_y_axis_2)
+
+    def test_release_y_axis_clears_right_secondary_reference(self):
+        # arrange
+        component = MagicMock()
+        values = np.linspace(0.0, 1.0, 10)
+        abscissa = Expression("Time", values, "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        axis = MagicMock()
+        axis.property.return_value = "W"
+        chart._right_y_axis_2 = axis
+        chart._y_axes = {"W": axis}
+        chart._y_axes_ref_counts = {axis: 1}
+        # act
+        removed = chart._release_y_axis(axis)
+        # assert
+        self.assertTrue(removed)
+        self.assertIsNone(chart._right_y_axis_2)
+
+    def test_sample_at_prefers_rendered_decimated_points_over_raw_samples(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 11, 1, 500)
+        # raw data has a narrow spike at x=5 that may be absent from rendered decimated points
+        vout = Expression("Vout", np.array([0.0, 0.5, 1.0, 2.0, 3.2, 4.2, 3.1, 2.0, 1.0, 0.5, 0.0]), "V")
+        mock_axis = MagicMock()
+        chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 0.0, 4.2, "#f77f00")})
+        # rendered decimated points shown on chart near the same x do not include the raw spike
+        chart._sample_cache[vout] = {0: (np.array([0.0, 5.0, 10.0]), np.array([0.0, 3.9, 0.0]))}
+        # act
+        result = chart.sample_at(0.5)
+        # assert
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0][0], "Vout")
+        self.assertEqual(result[0][1], "V")
+        self.assertEqual(result[0][2], [3.9])
 
     def test_abscissa_property(self):
         # arrange
@@ -777,12 +1005,12 @@ class TestChart(TestCase):
         # act
         with patch("viewer.chart.decimate_xy", return_value=(values, decimated_y)):
             chart.plot_series({vout})
-        # assert — series stored without raising; padded bounds surround the constant value
+        # assert — series stored without raising and min/max reflect the rendered values
         self.assertIn("Vout", chart._series)
         _, ordinate_series = chart._series["Vout"]
         _, _, stored_min, stored_max, _ = ordinate_series[vout]
-        self.assertLess(stored_min, 3.0)
-        self.assertGreater(stored_max, 3.0)
+        self.assertEqual(stored_min, 3.0)
+        self.assertEqual(stored_max, 3.0)
 
     def test_plot_series_handles_all_zero_signal(self):
         # arrange — all ordinate values are zero: scale == 0 triggers the else branch (y_range = 1.0)
@@ -795,12 +1023,12 @@ class TestChart(TestCase):
         # act
         with patch("viewer.chart.decimate_xy", return_value=(values, decimated_y)):
             chart.plot_series({vout})
-        # assert — series stored; padded bounds extend below and above zero
+        # assert — series stored and min/max reflect the rendered values
         self.assertIn("Vout", chart._series)
         _, ordinate_series = chart._series["Vout"]
         _, _, stored_min, stored_max, _ = ordinate_series[vout]
-        self.assertLess(stored_min, 0.0)
-        self.assertGreater(stored_max, 0.0)
+        self.assertEqual(stored_min, 0.0)
+        self.assertEqual(stored_max, 0.0)
 
     def test_redraw_all_series_handles_constant_signal(self):
         # arrange — constant ordinate so the flat-signal y_range fix fires inside _redraw_all_series

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -19,7 +19,7 @@ sys.modules["PySide6.QtCore"].Slot = lambda *a, **kw: (lambda f: f)
 sys.modules["PySide6.QtWidgets"].QMainWindow = type("QMainWindow", (), {})
 
 from viewer.expression import Expression  # noqa: E402
-from viewer.main_window import MainWindow, _build_step_combinations, _format_value, _format_values  # noqa: E402
+from viewer.main_window import MainWindow, _build_step_combinations, _compute_decimate_target, _FALLBACK_DECIMATE_TARGET, _format_value, _format_values  # noqa: E402
 
 
 class TestMainWindow(TestCase):
@@ -608,3 +608,44 @@ class TestMultiStepFft(TestCase):
         abscissa_expr = [e for e in captured_expressions if e.name == "Frequency"][0]
         self.assertEqual(len(fft_expr.data), steps * freq_points)
         self.assertEqual(len(abscissa_expr.data), freq_points)
+
+
+class TestComputeDecimateTarget(TestCase):
+
+    def test_returns_fallback_when_screen_is_none(self):
+        # arrange
+        screen = None
+        # act
+        result = _compute_decimate_target(screen)
+        # assert
+        self.assertEqual(result, _FALLBACK_DECIMATE_TARGET)
+
+    def test_uses_screen_width_and_pixel_ratio(self):
+        # arrange
+        screen = MagicMock()
+        screen.size.return_value.width.return_value = 2560
+        screen.devicePixelRatio.return_value = 2.0
+        # act
+        result = _compute_decimate_target(screen)
+        # assert
+        self.assertEqual(result, 2560 * 5)
+
+    def test_pixel_ratio_below_five_is_clamped_to_five(self):
+        # arrange
+        screen = MagicMock()
+        screen.size.return_value.width.return_value = 1920
+        screen.devicePixelRatio.return_value = 1.0
+        # act
+        result = _compute_decimate_target(screen)
+        # assert
+        self.assertEqual(result, 1920 * 5)
+
+    def test_high_pixel_ratio_is_used_directly(self):
+        # arrange
+        screen = MagicMock()
+        screen.size.return_value.width.return_value = 3840
+        screen.devicePixelRatio.return_value = 8.0
+        # act
+        result = _compute_decimate_target(screen)
+        # assert
+        self.assertEqual(result, 3840 * 8)

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -11,6 +11,7 @@ sys.modules.setdefault("PySide6.QtGui", MagicMock())
 sys.modules.setdefault("PySide6.QtGraphs", MagicMock())
 sys.modules.setdefault("PySide6.QtQml", MagicMock())
 sys.modules.setdefault("PySide6.QtQuick", MagicMock())
+sys.modules.setdefault("PySide6.QtWebEngineWidgets", MagicMock())
 sys.modules.setdefault("PySide6.QtWidgets", MagicMock())
 # Slot must act as a pass-through decorator so @Slot(...) does not replace the method with a mock
 sys.modules["PySide6.QtCore"].Slot = lambda *a, **kw: (lambda f: f)
@@ -393,3 +394,52 @@ class TestMainWindowSlots(TestCase):
         # assert — QSize is mocked so just verify the call was made with the right args
         # actual assertion: method exists and returns something (integration check is enough here)
         self.assertIsNotNone(result)
+
+    def test_pointer_moved_uses_chart_public_sampling_api(self):
+        # arrange
+        win = self._make_win(total=20)
+        win._abscissa = MagicMock(unit="s", data=list(range(20)), values=list(range(20)))
+        win._abscissa.name = "time"
+        win._abscissa_scale = "linear"
+        win._last_status_time = 0.0
+        win.statusBar = MagicMock(return_value=MagicMock())
+        chart = MagicMock()
+        chart.sample_index_at_ratio.return_value = 7
+        chart.sample_at.return_value = [("V(out)", "V", [1.23])]
+        win._charts = [chart]
+        # act
+        win._on_pointer_moved(0, 0.35)
+        # assert
+        chart.sample_index_at_ratio.assert_called_once_with(0.35)
+        chart.sample_at.assert_called_once_with(0.35)
+
+    def test_pointer_moved_ignores_invalid_chart_index(self):
+        # arrange
+        win = self._make_win(total=20)
+        win._last_status_time = 0.0
+        win.statusBar = MagicMock(return_value=MagicMock())
+        chart = MagicMock()
+        win._charts = [chart]
+        # act
+        win._on_pointer_moved(99, 0.5)
+        # assert
+        chart.sample_index_at_ratio.assert_not_called()
+        chart.sample_at.assert_not_called()
+
+    def test_pointer_moved_updates_status_bar_message(self):
+        # arrange
+        win = self._make_win(total=20)
+        win._abscissa = MagicMock(unit="s", data=list(range(20)), values=list(range(20)))
+        win._abscissa.name = "time"
+        win._abscissa_scale = "linear"
+        win._last_status_time = 0.0
+        status_bar = MagicMock()
+        win.statusBar = MagicMock(return_value=status_bar)
+        chart = MagicMock()
+        chart.sample_index_at_ratio.return_value = 5
+        chart.sample_at.return_value = [("V(out)", "V", [1.0])]
+        win._charts = [chart]
+        # act
+        win._on_pointer_moved(0, 0.2)
+        # assert
+        status_bar.showMessage.assert_called_once_with("time = 5.00 s    V(out) = 1.00 V")

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -451,7 +451,6 @@ class TestMultiStepFft(TestCase):
     def _make_fft_win(self, steps: int, step_points: int):
         # build a bare MainWindow bypassing __init__
         win = MainWindow.__new__(MainWindow)
-        total = steps * step_points
         win._abscissa = MagicMock(data=np.linspace(0.0, 1e-3, step_points), unit="s")
         win._abscissa.name = "Time"
         win._abscissa_from_index = 0
@@ -497,13 +496,16 @@ class TestMultiStepFft(TestCase):
         win._charts = [chart]
         dialog_class = self._make_dialog_mock(expr, step_points)
         captured_qraw = []
+
         def fake_qraw(**kw):
             captured_qraw.append(kw)
             return MagicMock()
+
         def fake_main_window(qraw, source_qraw_path=None):
             win2 = MagicMock()
             win2._initial_selected_steps = None
             return win2
+
         with patch("viewer.main_window.FftDialog", dialog_class), \
              patch("viewer.main_window.QRawFile", fake_qraw), \
              patch("viewer.main_window.MainWindow", fake_main_window), \
@@ -529,13 +531,16 @@ class TestMultiStepFft(TestCase):
         win._charts = [chart]
         dialog_class = self._make_dialog_mock(expr, step_points)
         captured_steps = []
+
         def fake_qraw(**kw):
             captured_steps.append(kw.get("steps"))
             return MagicMock()
+
         def fake_main_window(qraw, source_qraw_path=None):
             win2 = MagicMock()
             win2._initial_selected_steps = None
             return win2
+
         with patch("viewer.main_window.FftDialog", dialog_class), \
              patch("viewer.main_window.QRawFile", fake_qraw), \
              patch("viewer.main_window.MainWindow", fake_main_window), \
@@ -561,11 +566,13 @@ class TestMultiStepFft(TestCase):
         win._charts = [chart]
         dialog_class = self._make_dialog_mock(expr, step_points)
         created_windows = []
+
         def fake_main_window(qraw, source_qraw_path=None):
             win2 = MagicMock()
             win2._initial_selected_steps = None
             created_windows.append(win2)
             return win2
+
         with patch("viewer.main_window.FftDialog", dialog_class), \
              patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
              patch("viewer.main_window.MainWindow", fake_main_window), \
@@ -592,9 +599,11 @@ class TestMultiStepFft(TestCase):
         win._charts = [chart]
         dialog_class = self._make_dialog_mock(expr, step_points)
         captured_expressions = []
+
         def fake_expr_mgr(expressions):
             captured_expressions.extend(expressions)
             return MagicMock()
+
         with patch("viewer.main_window.FftDialog", dialog_class), \
              patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
              patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)), \

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -1,6 +1,6 @@
 import sys
 from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -325,6 +325,7 @@ class TestMainWindowSlots(TestCase):
         win._steps = 1
         win._decimate_target = 500
         win._plot_suggestions = []
+        win._initial_selected_steps = None
         win._root = MagicMock()
         win._root.getChart.return_value = MagicMock()
         # act
@@ -443,3 +444,167 @@ class TestMainWindowSlots(TestCase):
         win._on_pointer_moved(0, 0.2)
         # assert
         status_bar.showMessage.assert_called_once_with("time = 5.00 s    V(out) = 1.00 V")
+
+
+class TestMultiStepFft(TestCase):
+
+    def _make_fft_win(self, steps: int, step_points: int):
+        # build a bare MainWindow bypassing __init__
+        win = MainWindow.__new__(MainWindow)
+        total = steps * step_points
+        win._abscissa = MagicMock(data=np.linspace(0.0, 1e-3, step_points), unit="s")
+        win._abscissa.name = "Time"
+        win._abscissa_from_index = 0
+        win._abscissa_to_index = step_points
+        win._steps = steps
+        win._qraw_path = MagicMock()
+        win._fft_windows = []
+        win._charts = []
+        win._abscissa_scale = MagicMock()
+        return win
+
+    def _make_dialog_mock(self, expr: Expression, step_points: int):
+        # build a FftDialog mock whose .exec() returns Accepted via a shared sentinel
+        _accepted = object()
+        dialog = MagicMock()
+        dialog.exec.return_value = _accepted
+        dialog.result_expressions = [expr]
+        dialog.result_from_index = 0
+        dialog.result_to_index = step_points
+        dialog.result_window = MagicMock(value="Rectangular")
+        dialog.result_zero_pad = MagicMock(value="None")
+        dialog.result_normalize = False
+        dialog.result_keep_dc = True
+        dialog.result_output = MagicMock()
+        # make the Dialog class itself (not instance) carry DialogCode
+        dialog_class = MagicMock()
+        dialog_class.return_value = dialog
+        dialog_class.DialogCode.Accepted = _accepted
+        return dialog_class
+
+    def test_fft_builds_expression_data_for_all_steps(self):
+        # arrange
+        steps = 3
+        step_points = 64
+        win = self._make_fft_win(steps, step_points)
+        # source expression: distinct value per step so we can verify which step was used
+        data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
+        expr = Expression("V(out)", data, "V")
+        chart = MagicMock()
+        chart.expressions = [expr]
+        chart.abscissa = win._abscissa
+        chart.selected_steps = {0, 1, 2}
+        win._charts = [chart]
+        dialog_class = self._make_dialog_mock(expr, step_points)
+        captured_qraw = []
+        def fake_qraw(**kw):
+            captured_qraw.append(kw)
+            return MagicMock()
+        def fake_main_window(qraw, source_qraw_path=None):
+            win2 = MagicMock()
+            win2._initial_selected_steps = None
+            return win2
+        with patch("viewer.main_window.FftDialog", dialog_class), \
+             patch("viewer.main_window.QRawFile", fake_qraw), \
+             patch("viewer.main_window.MainWindow", fake_main_window), \
+             patch("viewer.main_window.compute_fft_many") as mock_fft, \
+             patch("viewer.main_window.ExpressionManager"):
+            freq = np.linspace(0, 500, 33)
+            mock_fft.return_value = (freq, np.ones((1, 33)))
+            win._on_menu_fft(0)
+        # assert — compute_fft_many called once per step
+        self.assertEqual(mock_fft.call_count, steps)
+
+    def test_fft_qraw_built_with_all_steps(self):
+        # arrange
+        steps = 3
+        step_points = 64
+        win = self._make_fft_win(steps, step_points)
+        data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
+        expr = Expression("V(out)", data, "V")
+        chart = MagicMock()
+        chart.expressions = [expr]
+        chart.abscissa = win._abscissa
+        chart.selected_steps = {1, 2}
+        win._charts = [chart]
+        dialog_class = self._make_dialog_mock(expr, step_points)
+        captured_steps = []
+        def fake_qraw(**kw):
+            captured_steps.append(kw.get("steps"))
+            return MagicMock()
+        def fake_main_window(qraw, source_qraw_path=None):
+            win2 = MagicMock()
+            win2._initial_selected_steps = None
+            return win2
+        with patch("viewer.main_window.FftDialog", dialog_class), \
+             patch("viewer.main_window.QRawFile", fake_qraw), \
+             patch("viewer.main_window.MainWindow", fake_main_window), \
+             patch("viewer.main_window.compute_fft_many") as mock_fft, \
+             patch("viewer.main_window.ExpressionManager"):
+            freq = np.linspace(0, 500, 33)
+            mock_fft.return_value = (freq, np.ones((1, 33)))
+            win._on_menu_fft(0)
+        # assert — QRawFile receives steps=3 (all source steps, not just selected)
+        self.assertEqual(captured_steps[0], steps)
+
+    def test_fft_window_initial_selected_steps_matches_source_chart(self):
+        # arrange
+        steps = 5
+        step_points = 64
+        win = self._make_fft_win(steps, step_points)
+        data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
+        expr = Expression("V(out)", data, "V")
+        chart = MagicMock()
+        chart.expressions = [expr]
+        chart.abscissa = win._abscissa
+        chart.selected_steps = {1, 2}
+        win._charts = [chart]
+        dialog_class = self._make_dialog_mock(expr, step_points)
+        created_windows = []
+        def fake_main_window(qraw, source_qraw_path=None):
+            win2 = MagicMock()
+            win2._initial_selected_steps = None
+            created_windows.append(win2)
+            return win2
+        with patch("viewer.main_window.FftDialog", dialog_class), \
+             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
+             patch("viewer.main_window.MainWindow", fake_main_window), \
+             patch("viewer.main_window.compute_fft_many") as mock_fft, \
+             patch("viewer.main_window.ExpressionManager"):
+            freq = np.linspace(0, 500, 33)
+            mock_fft.return_value = (freq, np.ones((1, 33)))
+            win._on_menu_fft(0)
+        # assert — FFT window initial step selection matches source chart selected steps
+        self.assertEqual(created_windows[0]._initial_selected_steps, {1, 2})
+
+    def test_fft_expression_data_length_is_steps_times_freq_points(self):
+        # arrange
+        steps = 2
+        step_points = 64
+        freq_points = 33
+        win = self._make_fft_win(steps, step_points)
+        data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
+        expr = Expression("V(out)", data, "V")
+        chart = MagicMock()
+        chart.expressions = [expr]
+        chart.abscissa = win._abscissa
+        chart.selected_steps = {0, 1}
+        win._charts = [chart]
+        dialog_class = self._make_dialog_mock(expr, step_points)
+        captured_expressions = []
+        def fake_expr_mgr(expressions):
+            captured_expressions.extend(expressions)
+            return MagicMock()
+        with patch("viewer.main_window.FftDialog", dialog_class), \
+             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
+             patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)), \
+             patch("viewer.main_window.compute_fft_many") as mock_fft, \
+             patch("viewer.main_window.ExpressionManager", fake_expr_mgr):
+            freq = np.linspace(0, 500, freq_points)
+            mock_fft.return_value = (freq, np.ones((1, freq_points)))
+            win._on_menu_fft(0)
+        # assert — FFT expression data length = steps * freq_points; abscissa = freq_points only
+        fft_expr = [e for e in captured_expressions if e.name != "Frequency"][0]
+        abscissa_expr = [e for e in captured_expressions if e.name == "Frequency"][0]
+        self.assertEqual(len(fft_expr.data), steps * freq_points)
+        self.assertEqual(len(abscissa_expr.data), freq_points)

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -360,6 +360,10 @@ class Chart:
                 return []
             # exit
             return [magnitude_expression, phase_expression]
+        # complex expressions are only renderable in AC charts; skip with a warning for other chart types
+        logger.warning("skipping complex expression '%s': not supported for chart type '%s'", expression.name, self._chart_type)
+        # exit
+        return []
 
     def _redraw_all_series(self):
         # abscissa values — shared across all ordinate steps, will be paired with y below

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -315,10 +315,8 @@ class Chart:
         # check series are plotted
         if not self._series:
             return []
-        # x zoom window indexes
-        from_index, _, to_index, _ = self._zoom_window
         # compute the nearest sample index within the current zoom window
-        idx = max(from_index, min(to_index - 1, int(round(from_index + x_ratio * (to_index - from_index)))))
+        idx = self.sample_index_at_ratio(x_ratio)
         # collect one (name, unit, value) tuple per plotted variant (magnitude/phase counted separately)
         result: list[tuple[str, str, list[float]]] = []
         # loop series
@@ -335,6 +333,16 @@ class Chart:
                 result.append((ordinate_variant.name, ordinate_variant.unit, values))
         # exit
         return result
+
+    def zoom_abscissa_bounds(self) -> tuple[int, int]:
+        # current abscissa bounds in sample indexes
+        return self._zoom_window[0], self._zoom_window[2]
+
+    def sample_index_at_ratio(self, x_ratio: float) -> int:
+        # x zoom window indexes
+        from_index, to_index = self.zoom_abscissa_bounds()
+        # compute the nearest sample index within the current zoom window
+        return max(from_index, min(to_index - 1, int(round(from_index + x_ratio * (to_index - from_index)))))
 
     def _get_expressions_to_plot(self, expression: Expression) -> list[Expression]:
         # check we can plot expression as is

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -48,6 +48,8 @@ class Chart:
         self._decimate_target = decimate_target
         # track active series
         self._series: dict[str, tuple[Expression, dict[Expression, tuple[QAbstractAxis, dict[int, QLineSeries], float, float, str]]]] = {}
+        # decimated sample cache used by status-bar probing: {ordinate_variant: {step: (x_np, y_np)}}
+        self._sample_cache: dict[Expression, dict[int, tuple[np.ndarray, np.ndarray]]] = {}
         # axis tracking for measurement types, e.g. {"V": <QAbstractAxis>, "I": <QAbstractAxis>}
         self._y_axes: dict[str, QAbstractAxis] = {}
         self._y_axes_ref_counts: dict[QAbstractAxis, int] = {}
@@ -115,6 +117,8 @@ class Chart:
                     # release axis if no longer in use
                     if self._release_y_axis(axis):
                         axes_to_remove.append(axis)
+                    # clear decimated sample cache for this plotted variant
+                    self._sample_cache.pop(ordinate_variant, None)
                     # append to list for later removal from chart
                     series_to_remove.append([ordinate_variant.name, list(rendered_series.values())])
                 # remove from tracked series so we don't try to update it later
@@ -138,6 +142,10 @@ class Chart:
                         series_to_remove.append([None, [rendered_series[step]]])
                         # remove from dictionary so we don't try to update it later
                         del rendered_series[step]
+                        # check decimated sample cache exists for this plotted variant
+                        if ordinate_variant in self._sample_cache:
+                            # remove cached points for this step
+                            self._sample_cache[ordinate_variant].pop(step, None)
                 # check we need to generate a color for this expression
                 if color is None:
                     # assign next color in palette
@@ -185,6 +193,8 @@ class Chart:
                         series.setDashPattern([3, step + 1])
                     # append to lists
                     rendered_series[step] = series
+                    # cache decimated points used by the rendered series for status probing
+                    self._sample_cache.setdefault(ordinate_variant, {})[step] = (x_np, y_np)
                     # append to list for later addition to chart
                     ordinate_series_to_render.append(series)
                     # update min and max values
@@ -192,16 +202,8 @@ class Chart:
                     max_value = max(max_value, float(np.max(y_np)))
                 # render new series
                 series_to_render.append([ordinate_variant.name if ordinate_variant not in ordinate_series else None, color, ordinate_series_to_render])
-                # calculate scale for Y axis
-                scale = max(abs(max_value), abs(min_value))
-                # Y axis range
-                y_range = max_value - min_value
-                if y_range <= scale * 1e-9:
-                    y_range = abs(max_value) * 0.01 if scale != 0 else 1.0
-                # protect against very small ranges
-                delta = max(0.01 * y_range, 1e-3)
                 # store series with min and max values for later use when auto-ranging axes
-                ordinate_series[ordinate_variant] = (y_axis, rendered_series, min_value - delta if min_value != float("inf") else min_value, max_value + delta if max_value != float("-inf") else max_value, color)
+                ordinate_series[ordinate_variant] = (y_axis, rendered_series, min_value, max_value, color)
             # store reference to allow removal later
             self._series[ordinate.name] = (ordinate, ordinate_series)
         # check changes are required in qml
@@ -227,8 +229,12 @@ class Chart:
                 self._axis_ranges[y_axis] = (min(current_min, min_value), max(current_max, max_value))
         # update axis ranges based on collected min and max values for each variable type
         for y_axis, (y_min, y_max) in self._axis_ranges.items():
+            # range
+            y_range = y_max - y_min
+            # delta
+            delta = 0.03 * y_range
             # set y axis range
-            y_axis.setRange(y_min, y_max)
+            y_axis.setRange(y_min - delta, y_max + delta)
 
     def update_zoom_window(self, abscissa_from_index: int, abscissa_to_index: int, y_top_ratio: float | None, y_bottom_ratio: float | None):
         # vertical changes flag
@@ -295,6 +301,7 @@ class Chart:
         old_y_axes = self._y_axes
         # reset internal state
         self._series = {}
+        self._sample_cache = {}
         self._y_axes = {}
         self._y_axes_ref_counts = {}
         # reset color index for new series
@@ -315,6 +322,17 @@ class Chart:
         # check series are plotted
         if not self._series:
             return []
+        # clamped horizontal ratio in visible window
+        x_ratio = max(0.0, min(1.0, x_ratio))
+        # current horizontal zoom bounds
+        from_index, to_index = self.zoom_abscissa_bounds()
+        # visible abscissa window
+        window = self._abscissa.data[from_index:to_index]
+        # check visible window is empty
+        if window.size == 0:
+            return []
+        # target abscissa value under the cursor in the visible window
+        target_x = float(window[0] + x_ratio * (window[-1] - window[0]))
         # compute the nearest sample index within the current zoom window
         idx = self.sample_index_at_ratio(x_ratio)
         # collect one (name, unit, value) tuple per plotted variant (magnitude/phase counted separately)
@@ -327,7 +345,20 @@ class Chart:
                 values: list[float] = []
                 # step and series for this step
                 for step, _ in rendered_series.items():
-                    # value for step at index
+                    # check decimated points are available for this visible step
+                    sample_points = self._sample_cache.get(ordinate_variant, {}).get(step)
+                    if sample_points is not None:
+                        # decimated x and y arrays for the rendered step
+                        x_np, y_np = sample_points
+                        # check decimated arrays are not empty
+                        if x_np.size > 0 and y_np.size > 0:
+                            # nearest rendered sample index in x-space
+                            nearest_index = int(np.argmin(np.abs(x_np - target_x)))
+                            # append rendered y value at nearest x
+                            values.append(float(y_np[nearest_index]))
+                            # next rendered step
+                            continue
+                    # fallback to raw value at nearest original sample index
                     values.append(float(ordinate_variant.data[step * self._step_points + idx]))
                 # append to result (name, unit, value)
                 result.append((ordinate_variant.name, ordinate_variant.unit, values))
@@ -341,8 +372,60 @@ class Chart:
     def sample_index_at_ratio(self, x_ratio: float) -> int:
         # x zoom window indexes
         from_index, to_index = self.zoom_abscissa_bounds()
-        # compute the nearest sample index within the current zoom window
-        return max(from_index, min(to_index - 1, int(round(from_index + x_ratio * (to_index - from_index)))))
+        # clamp ratio to visible horizontal span
+        x_ratio = max(0.0, min(1.0, x_ratio))
+        # window length
+        window_len = to_index - from_index
+        # check visible window has a single point
+        if window_len <= 1:
+            # return only sample index in window
+            return from_index
+        # visible abscissa window which can be non-uniformly spaced
+        window = self._abscissa.data[from_index:to_index]
+        # target x value on the visible axis for the given cursor ratio
+        target = float(window[0] + x_ratio * (window[-1] - window[0]))
+        # check ascending abscissa ordering
+        if window[0] <= window[-1]:
+            # insertion index in visible window
+            insert_at = int(np.searchsorted(window, target, side="left"))
+            # check target is left of the first visible sample
+            if insert_at <= 0:
+                # clamp to left bound
+                return from_index
+            # check target is right of the last visible sample
+            if insert_at >= window_len:
+                # clamp to right bound
+                return to_index - 1
+            # nearest neighbors around insertion point
+            left_idx = insert_at - 1
+            right_idx = insert_at
+            # distance to left neighbor
+            left_dist = abs(float(window[left_idx]) - target)
+            # distance to right neighbor
+            right_dist = abs(float(window[right_idx]) - target)
+            # select the closest index and break ties to the left
+            return from_index + (left_idx if left_dist <= right_dist else right_idx)
+        # descending abscissa search on reversed view
+        reversed_window = window[::-1]
+        # insertion index in reversed visible window
+        insert_at = int(np.searchsorted(reversed_window, target, side="left"))
+        # check target is left of the first visible sample in descending order
+        if insert_at <= 0:
+            # clamp to right bound in original ordering
+            return to_index - 1
+        # check target is right of the last visible sample in descending order
+        if insert_at >= window_len:
+            # clamp to left bound in original ordering
+            return from_index
+        # map insertion point neighbors back to original ordering
+        right_idx = window_len - insert_at
+        left_idx = right_idx - 1
+        # distance to left neighbor
+        left_dist = abs(float(window[left_idx]) - target)
+        # distance to right neighbor
+        right_dist = abs(float(window[right_idx]) - target)
+        # select the closest index and break ties to the left
+        return from_index + (left_idx if left_dist <= right_dist else right_idx)
 
     def _get_expressions_to_plot(self, expression: Expression) -> list[Expression]:
         # check we can plot expression as is
@@ -392,6 +475,8 @@ class Chart:
                         y_np = y_np[finite_mask]
                         # update series with decimated data
                         series.replaceNp(x_np, y_np)
+                        # cache decimated points used by the rendered series for status probing
+                        self._sample_cache.setdefault(ordinate_variant, {})[step] = (x_np, y_np)
                         # update min and max values
                         min_value = min(min_value, float(np.min(y_np)))
                         max_value = max(max_value, float(np.max(y_np)))

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -137,6 +137,17 @@ def _build_step_combinations(expressions: list[Expression], steps: int, step_poi
     return parameter_names, combinations
 
 
+_FALLBACK_DECIMATE_TARGET = 9600
+
+
+def _compute_decimate_target(screen) -> int:
+    # return conservative fallback when no screen is available (headless / early startup)
+    if screen is None:
+        return _FALLBACK_DECIMATE_TARGET
+    # physical pixels: width × clamped device-pixel ratio
+    return screen.size().width() * max(5, int(screen.devicePixelRatio()))
+
+
 class MainWindow(QMainWindow):
 
     def __init__(self, qraw_file: QRawFile, source_qraw_path: Path | None = None):
@@ -194,8 +205,7 @@ class MainWindow(QMainWindow):
         # create the native main menu structure
         self._create_main_menu()
         # decimation target — physical pixels of the primary screen width
-        screen = QGuiApplication.primaryScreen()
-        self._decimate_target = screen.size().width() * max(5, int(screen.devicePixelRatio()))
+        self._decimate_target = _compute_decimate_target(QGuiApplication.primaryScreen())
         # throttle timestamp for status bar updates
         self._last_status_time: float = 0.0
 

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -174,6 +174,9 @@ class MainWindow(QMainWindow):
         self._charts: list[Chart] = []
         # keep FFT result windows alive to prevent garbage collection
         self._fft_windows: list[MainWindow] = []
+        # optional initial step selection applied when charts are first created (used by FFT windows to
+        # pre-focus on the same steps the user was viewing in the source chart)
+        self._initial_selected_steps: set[int] | None = None
         # keep Jupyter windows alive to prevent garbage collection
         self._jupyter_windows: list[JupyterWindow] = []
         # default horizontal zoom
@@ -304,6 +307,9 @@ class MainWindow(QMainWindow):
         chart_root = self._root.getChart(chart_index)
         # create chart instance
         chart = Chart(chart_root, chart_type, self._expression_manager, self._abscissa, self._abscissa_from_index, self._abscissa_to_index, self._steps, self._decimate_target)
+        # apply initial step selection when provided (e.g. FFT window inheriting source chart visibility)
+        if self._initial_selected_steps is not None:
+            chart.selected_steps = self._initial_selected_steps
         # add it to the list of charts so we can keep track of it
         self._charts.append(chart)
         # render chart
@@ -493,37 +499,54 @@ class MainWindow(QMainWindow):
         output = dialog.result_output
         # number of samples per step (abscissa is already trimmed to one period)
         step_points = len(self._abscissa.data)
-        # shared abscissa slice for all selected expressions
+        # shared abscissa slice — identical across all steps since the abscissa is periodic
         x = self._abscissa.data[from_index:to_index]
-        # build a dense matrix of selected signals using the shared x slice
-        y_matrix = np.vstack([expression.data[0:step_points][from_index:to_index] for expression in result_expressions])
-        try:
-            # compute FFT for all selected expressions in a single batch call
-            frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
-        except ValueError:
-            # log exception and abort when the shared batch computation fails
-            logger.exception("Batch FFT computation failed for chart %d", chart_index)
-            # exit
-            return
+        # accumulate per-expression FFT arrays for each step; outer list is per-expression,
+        # inner list is one array per step
+        per_expression_steps: list[list[np.ndarray]] = [[] for _ in result_expressions]
+        # frequencies are the same for every step; capture once from the first batch
+        frequencies: np.ndarray | None = None
+        # loop all steps so the FFT window always has the full dataset
+        for step in range(self._steps):
+            # build signal matrix for this step: each row is one expression, columns are time samples
+            y_matrix = np.vstack([expression.data[step * step_points:(step + 1) * step_points][from_index:to_index] for expression in result_expressions])
+            try:
+                # compute FFT for all selected expressions in a single batch call
+                step_frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
+            except ValueError:
+                # log exception and abort when the shared batch computation fails
+                logger.exception("Batch FFT computation failed for chart %d step %d", chart_index, step)
+                # exit
+                return
+            # capture frequencies once; they are the same for every step
+            if frequencies is None:
+                frequencies = step_frequencies
+            # accumulate per-expression FFT results for this step
+            for expr_idx, fft_values in enumerate(fft_matrix):
+                per_expression_steps[expr_idx].append(fft_values)
         # guard against an unexpectedly empty frequency axis
-        if len(frequencies) == 0:
+        if frequencies is None or len(frequencies) == 0:
             # log error and abort when no frequencies are returned
             logger.error("FFT computation returned an empty frequency axis for chart %d", chart_index)
             # exit
             return
-        # build FFT expressions preserving the selected input order (strip spaces from expression name, it is required for plot suggestions to work correctly in the new window)
-        fft_expressions = [Expression(f"FFT({expression.name.replace(' ', '')})", fft_values, "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)) for expression, fft_values in zip(result_expressions, fft_matrix)]
-        # create frequency expression for the shared abscissa
+        # build FFT expressions: concatenate per-step arrays so data layout mirrors the source simulation
+        # (steps * freq_points values, step segments laid out contiguously)
+        fft_expressions = [Expression(f"FFT({expression.name.replace(' ', '')})", np.concatenate(step_fft_list), "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)) for expression, step_fft_list in zip(result_expressions, per_expression_steps)]
+        # create frequency expression — length matches a single step period (freq_points)
         freq_expression = Expression("Frequency", frequencies, "Hz")
         # build expression manager with frequency abscissa and all FFT results
         expression_manager = ExpressionManager([freq_expression] + fft_expressions)
         # build one «name» group per FFT expression so each gets its own chart
         plot_suggestion = " ".join(f"\xabfft {e.name}\xbb" for e in fft_expressions)
-        # create a synthetic QRawFile with frequency abscissa and all FFT values
-        fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT \u2013 {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, steps=1, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
+        # create a synthetic QRawFile with frequency abscissa and all FFT values;
+        # steps matches the source simulation so the FFT window inherits full step coverage
+        fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT \u2013 {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, steps=self._steps, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
         # create a new MainWindow to render the FFT result using the existing infrastructure;
         # pass the original source path so Jupyter always opens the correct .qraw file
         fft_window = MainWindow(fft_qraw, source_qraw_path=self._qraw_path)
+        # pre-focus the FFT window on the same steps the user was viewing in the source chart
+        fft_window._initial_selected_steps = chart.selected_steps
         # keep reference alive to prevent garbage collection
         self._fft_windows.append(fft_window)
         # show the FFT result window

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -543,9 +543,7 @@ class MainWindow(QMainWindow):
         # chart at index
         chart = self._charts[chart_index]
         # compute abscissa index within the current zoom window
-        from_index, _, to_index, _ = chart._zoom_window
-        # index within the zoom window based on the supplied x_ratio
-        idx = max(from_index, min(to_index - 1, int(round(from_index + x_ratio * (to_index - from_index)))))
+        idx = chart.sample_index_at_ratio(x_ratio)
         # retrieve the stored abscissa value (may be in log space for decade/octave scales)
         x_stored = float(self._abscissa.data[idx])
         # convert stored value back to physical abscissa value


### PR DESCRIPTION
## Summary

Five commits on top of `main` (since #36):

### Internal refactoring (`e7f2acd`)
- `viewer/chart.py`: internal refactoring
- `viewer/main_window.py`: cleanup
- Tests: added coverage in `chart_test.py` and `main_window_test.py`

### Updated FFT calculation to use all steps in original signal (`3e3cd91`)
- `viewer/main_window.py`: FFT now processes all steps from the source signal
- Tests: comprehensive coverage for multi-step FFT path in `main_window_test.py`

### Refactoring (`5be0c0e`)
- `viewer/main_window.py`: further cleanup
- Tests: additional `main_window_test.py` coverage

### Added missing plots (`f174408`)
- `viewer/chart.py`: fix for missing plot cases
- Tests: regression tests in `chart_test.py`

### Bug fixes (`5c13ef3`)
- `viewer/chart.py`: targeted bug fixes
- Tests: 254-line expansion of `chart_test.py` covering fixed cases

## Files changed
- `viewer/chart.py`
- `viewer/main_window.py`
- `tests/chart_test.py`
- `tests/main_window_test.py`