### PR TITLE
Batch FFT across all steps and signals in one pass

### DIFF
--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -522,10 +522,48 @@ class TestMultiStepFft(TestCase):
              patch("viewer.main_window.compute_fft_many") as mock_fft, \
              patch("viewer.main_window.ExpressionManager"):
             freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((1, 33)))
+            mock_fft.return_value = (freq, np.ones((steps, 33)))
             win._on_menu_fft(0)
-        # assert — compute_fft_many called once per step
-        self.assertEqual(mock_fft.call_count, steps)
+        # assert — one batched call computes all steps at once
+        self.assertEqual(mock_fft.call_count, 1)
+
+    def test_fft_batches_all_steps_and_expressions_in_single_matrix(self):
+        # arrange
+        steps = 3
+        step_points = 8
+        win = self._make_fft_win(steps, step_points)
+        expr_a = Expression("V(a)", np.concatenate([np.full(step_points, 10.0 + s) for s in range(steps)]), "V")
+        expr_b = Expression("V(b)", np.concatenate([np.full(step_points, 20.0 + s) for s in range(steps)]), "V")
+        chart = MagicMock()
+        chart.expressions = [expr_a, expr_b]
+        chart.abscissa = win._abscissa
+        chart.selected_steps = {0, 1, 2}
+        win._charts = [chart]
+        dialog_class = self._make_dialog_mock(expr_a, step_points)
+        dialog = dialog_class.return_value
+        dialog.result_expressions = [expr_a, expr_b]
+        captured_matrix = []
+
+        def fake_fft(x, y_matrix, *args, **kwargs):
+            captured_matrix.append(y_matrix.copy())
+            return np.linspace(0, 500, 5), np.ones((y_matrix.shape[0], 5))
+
+        with patch("viewer.main_window.FftDialog", dialog_class), \
+             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
+             patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)), \
+             patch("viewer.main_window.compute_fft_many", side_effect=fake_fft), \
+             patch("viewer.main_window.ExpressionManager"):
+            win._on_menu_fft(0)
+        # assert — matrix rows are expression-major with all steps included
+        self.assertEqual(len(captured_matrix), 1)
+        y_matrix = captured_matrix[0]
+        self.assertEqual(y_matrix.shape, (steps * 2, step_points))
+        np.testing.assert_array_equal(y_matrix[0], np.full(step_points, 10.0))
+        np.testing.assert_array_equal(y_matrix[1], np.full(step_points, 11.0))
+        np.testing.assert_array_equal(y_matrix[2], np.full(step_points, 12.0))
+        np.testing.assert_array_equal(y_matrix[3], np.full(step_points, 20.0))
+        np.testing.assert_array_equal(y_matrix[4], np.full(step_points, 21.0))
+        np.testing.assert_array_equal(y_matrix[5], np.full(step_points, 22.0))
 
     def test_fft_qraw_built_with_all_steps(self):
         # arrange
@@ -557,7 +595,7 @@ class TestMultiStepFft(TestCase):
              patch("viewer.main_window.compute_fft_many") as mock_fft, \
              patch("viewer.main_window.ExpressionManager"):
             freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((1, 33)))
+            mock_fft.return_value = (freq, np.ones((steps, 33)))
             win._on_menu_fft(0)
         # assert — QRawFile receives steps=3 (all source steps, not just selected)
         self.assertEqual(captured_steps[0], steps)
@@ -589,7 +627,7 @@ class TestMultiStepFft(TestCase):
              patch("viewer.main_window.compute_fft_many") as mock_fft, \
              patch("viewer.main_window.ExpressionManager"):
             freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((1, 33)))
+            mock_fft.return_value = (freq, np.ones((steps, 33)))
             win._on_menu_fft(0)
         # assert — FFT window initial step selection matches source chart selected steps
         self.assertEqual(created_windows[0]._initial_selected_steps, {1, 2})
@@ -622,7 +660,7 @@ class TestMultiStepFft(TestCase):
              patch("viewer.main_window.ExpressionManager"), \
              patch("viewer.main_window._register_fft_window") as mock_register:
             freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((1, 33)))
+            mock_fft.return_value = (freq, np.ones((steps, 33)))
             win._on_menu_fft(0)
         # assert
         mock_register.assert_called_once_with(created_windows[0])
@@ -653,13 +691,50 @@ class TestMultiStepFft(TestCase):
              patch("viewer.main_window.compute_fft_many") as mock_fft, \
              patch("viewer.main_window.ExpressionManager", fake_expr_mgr):
             freq = np.linspace(0, 500, freq_points)
-            mock_fft.return_value = (freq, np.ones((1, freq_points)))
+            mock_fft.return_value = (freq, np.ones((steps, freq_points)))
             win._on_menu_fft(0)
         # assert — FFT expression data length = steps * freq_points; abscissa = freq_points only
         fft_expr = [e for e in captured_expressions if e.name != "Frequency"][0]
         abscissa_expr = [e for e in captured_expressions if e.name == "Frequency"][0]
         self.assertEqual(len(fft_expr.data), steps * freq_points)
         self.assertEqual(len(abscissa_expr.data), freq_points)
+
+    def test_fft_expression_data_preserves_step_order(self):
+        # arrange
+        steps = 3
+        step_points = 64
+        freq_points = 33
+        win = self._make_fft_win(steps, step_points)
+        data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
+        expr = Expression("V(out)", data, "V")
+        chart = MagicMock()
+        chart.expressions = [expr]
+        chart.abscissa = win._abscissa
+        chart.selected_steps = {0, 1, 2}
+        win._charts = [chart]
+        dialog_class = self._make_dialog_mock(expr, step_points)
+        captured_expressions = []
+
+        def fake_expr_mgr(expressions):
+            captured_expressions.extend(expressions)
+            return MagicMock()
+
+        def fake_fft(x, y_matrix, *args, **kwargs):
+            # one row per step for this single expression; emit distinct value per row
+            row_values = np.array([np.full(freq_points, float(row_index)) for row_index in range(y_matrix.shape[0])])
+            return np.linspace(0, 500, freq_points), row_values
+        # act
+        with patch("viewer.main_window.FftDialog", dialog_class), \
+             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
+             patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)), \
+             patch("viewer.main_window.compute_fft_many", side_effect=fake_fft), \
+             patch("viewer.main_window.ExpressionManager", fake_expr_mgr):
+            win._on_menu_fft(0)
+        # assert — each step segment in the output buffer matches that step's value
+        fft_expr = [e for e in captured_expressions if e.name != "Frequency"][0]
+        for s in range(steps):
+            segment = fft_expr.data[s * freq_points:(s + 1) * freq_points]
+            np.testing.assert_array_equal(segment, np.full(freq_points, float(s)))
 
 
 class TestComputeDecimateTarget(TestCase):

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -525,42 +525,46 @@ class MainWindow(QMainWindow):
         normalize = dialog.result_normalize
         keep_dc = dialog.result_keep_dc
         output = dialog.result_output
-        # number of samples per step (abscissa is already trimmed to one period)
+        # number of samples per step (abscissa is already trimmed to one step)
         step_points = len(self._abscissa.data)
         # shared abscissa slice — identical across all steps since the abscissa is periodic
         x = self._abscissa.data[from_index:to_index]
-        # accumulate per-expression FFT arrays for each step; outer list is per-expression,
-        # inner list is one array per step
-        per_expression_steps: list[list[np.ndarray]] = [[] for _ in result_expressions]
-        # frequencies are the same for every step; capture once from the first batch
-        frequencies: np.ndarray | None = None
-        # loop all steps so the FFT window always has the full dataset
-        for step in range(self._steps):
-            # build signal matrix for this step: each row is one expression, columns are time samples
-            y_matrix = np.vstack([expression.data[step * step_points:(step + 1) * step_points][from_index:to_index] for expression in result_expressions])
-            try:
-                # compute FFT for all selected expressions in a single batch call
-                step_frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
-            except ValueError:
-                # log exception and abort when the shared batch computation fails
-                logger.exception("Batch FFT computation failed for chart %d step %d", chart_index, step)
-                # exit
-                return
-            # capture frequencies once; they are the same for every step
-            if frequencies is None:
-                frequencies = step_frequencies
-            # accumulate per-expression FFT results for this step
-            for expr_idx, fft_values in enumerate(fft_matrix):
-                per_expression_steps[expr_idx].append(fft_values)
+        # build one batch matrix for all expressions and all steps in expression-major order;
+        # rows are [expr0-step0, expr0-step1, ..., exprN-stepS]
+        signal_count = len(result_expressions)
+        sample_count = to_index - from_index
+        y_matrix = np.empty((signal_count * self._steps, sample_count))
+        # fill each expression block with all step slices at once
+        for expr_index, expression in enumerate(result_expressions):
+            row_start = expr_index * self._steps
+            row_end = row_start + self._steps
+            step_matrix = expression.data.reshape(self._steps, step_points)[:, from_index:to_index]
+            y_matrix[row_start:row_end] = step_matrix
+        try:
+            # compute FFT for all steps and expressions in one call
+            frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
+        except ValueError:
+            # log exception and abort
+            logger.exception("Batch FFT computation failed for chart %d", chart_index)
+            # exit
+            return
         # guard against an unexpectedly empty frequency axis
-        if frequencies is None or len(frequencies) == 0:
+        if len(frequencies) == 0:
             # log error and abort when no frequencies are returned
             logger.error("FFT computation returned an empty frequency axis for chart %d", chart_index)
             # exit
             return
-        # build FFT expressions: concatenate per-step arrays so data layout mirrors the source simulation
-        # (steps * freq_points values, step segments laid out contiguously)
-        fft_expressions = [Expression(f"FFT({expression.name.replace(' ', '')})", np.concatenate(step_fft_list), "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)) for expression, step_fft_list in zip(result_expressions, per_expression_steps)]
+        # number of frequency bins produced per step
+        freq_points = len(frequencies)
+        # build FFT expressions from row slices in the batched output matrix;
+        # each expression keeps step-major contiguous layout: [step0, step1, ..., stepS]
+        fft_expressions: list[Expression] = []
+        for expr_index, expression in enumerate(result_expressions):
+            row_start = expr_index * self._steps
+            row_end = row_start + self._steps
+            expression_data = fft_matrix[row_start:row_end].reshape(self._steps * freq_points)
+            expression_unit = "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)
+            fft_expressions.append(Expression(f"FFT({expression.name.replace(' ', '')})", expression_data, expression_unit))
         # create frequency expression — length matches a single step period (freq_points)
         freq_expression = Expression("Frequency", frequencies, "Hz")
         # build expression manager with frequency abscissa and all FFT results

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -533,15 +533,18 @@ class MainWindow(QMainWindow):
         # rows are [expr0-step0, expr0-step1, ..., exprN-stepS]
         signal_count = len(result_expressions)
         sample_count = to_index - from_index
+        # allocate dense batch buffer once; this owns the copied FFT input payload
         y_matrix = np.empty((signal_count * self._steps, sample_count))
         # fill each expression block with all step slices at once
         for expr_index, expression in enumerate(result_expressions):
             row_start = expr_index * self._steps
             row_end = row_start + self._steps
+            # reshape + slice are view operations when source layout is step-major contiguous
             step_matrix = expression.data.reshape(self._steps, step_points)[:, from_index:to_index]
+            # copy step block into the preallocated batch buffer
             y_matrix[row_start:row_end] = step_matrix
         try:
-            # compute FFT for all steps and expressions in one call
+            # fft internals allocate output arrays (spectrum/frequency/value matrices)
             frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
         except ValueError:
             # log exception and abort
@@ -562,6 +565,7 @@ class MainWindow(QMainWindow):
         for expr_index, expression in enumerate(result_expressions):
             row_start = expr_index * self._steps
             row_end = row_start + self._steps
+            # row slice is a view; reshape keeps a view for contiguous row blocks
             expression_data = fft_matrix[row_start:row_end].reshape(self._steps * freq_points)
             expression_unit = "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)
             fft_expressions.append(Expression(f"FFT({expression.name.replace(' ', '')})", expression_data, expression_unit))


### PR DESCRIPTION
Closes #44
Closes #43

Reworked `MainWindow._on_menu_fft` to build a single batched input matrix containing all selected expressions across all simulation steps, then call `compute_fft_many` once.

- Row layout is expression-major: `expr0-step0..stepN, expr1-step0..stepN, ...`
- FFT results are consumed by slicing row blocks per expression and reshaping to step-major contiguous expression data
- Eliminates the per-step repeated FFT calls and avoids the old final concatenate stage

Added tests to validate:
- single batched `compute_fft_many` call
- batched matrix contains all steps/expressions with expected row ordering
- output step ordering remains correct

## Validation

```bash
python -m unittest tests/main_window_test.py
flake8 viewer/main_window.py tests/main_window_test.py
```
