### PR TITLE
Fix decimate_xy early-return contiguity

### DIFF
--- a/tests/decimation_algorithm_test.py
+++ b/tests/decimation_algorithm_test.py
@@ -77,6 +77,35 @@ class TestDecimationAlgorithm(TestCase):
     def test_xy_average_short_circuit(self):
         self._assert_xy_short_circuit(DecimationAlgorithm.AVERAGE)
 
+    def test_xy_short_circuit_strided_inputs_become_contiguous(self):
+        # arrange
+        matrix = np.arange(400, dtype=np.float64).reshape(100, 4)
+        x = matrix[:, 0]
+        y = matrix[:, 1]
+        for algorithm in [DecimationAlgorithm.NTH_POINT, DecimationAlgorithm.MIN_MAX, DecimationAlgorithm.M4, DecimationAlgorithm.LTTB, DecimationAlgorithm.AVERAGE]:
+            # test for algo
+            with self.subTest(algorithm=algorithm):
+                # act
+                x_out, y_out = decimate_xy(x, y, 100, algorithm)
+                # assert
+                self.assertTrue(x_out.flags["C_CONTIGUOUS"])
+                self.assertTrue(y_out.flags["C_CONTIGUOUS"])
+                np.testing.assert_array_equal(x_out, x)
+                np.testing.assert_array_equal(y_out, y)
+
+    def test_xy_none_strided_inputs_become_contiguous(self):
+        # arrange
+        matrix = np.arange(400, dtype=np.float64).reshape(100, 4)
+        x = matrix[:, 2]
+        y = matrix[:, 3]
+        # act
+        x_out, y_out = decimate_xy(x, y, 10, DecimationAlgorithm.NONE)
+        # assert
+        self.assertTrue(x_out.flags["C_CONTIGUOUS"])
+        self.assertTrue(y_out.flags["C_CONTIGUOUS"])
+        np.testing.assert_array_equal(x_out, x)
+        np.testing.assert_array_equal(y_out, y)
+
     def _assert_length_le_target(self, algorithm: DecimationAlgorithm, target: int = 50):
         # arrange
         values = _sine(10_000)

--- a/viewer/decimation_algorithm.py
+++ b/viewer/decimation_algorithm.py
@@ -378,14 +378,14 @@ def decimate_xy(x: np.ndarray, y: np.ndarray, target: int, algorithm: Decimation
         raise ValueError("x and y must have the same length")
     if target < 1 and algorithm != DecimationAlgorithm.NONE:
         raise ValueError("target must be >= 1")
-    # NONE — pass both arrays through unchanged
+    # NONE — pass both arrays through unchanged while ensuring C-contiguous buffers for downstream Qt upload paths
     if algorithm == DecimationAlgorithm.NONE:
-        return x, y
+        return np.ascontiguousarray(x), np.ascontiguousarray(y)
     # vector length
     length = len(y)
-    # if we have fewer points than the target, just return the original arrays
+    # if we have fewer points than the target, return arrays directly while ensuring C-contiguous buffers for downstream Qt upload paths
     if length <= target:
-        return x, y
+        return np.ascontiguousarray(x), np.ascontiguousarray(y)
     # AVERAGE — bucket both x and y with the same bucket boundaries;
     # ceiling division ensures number_of_buckets <= target
     if algorithm == DecimationAlgorithm.AVERAGE:


### PR DESCRIPTION
## Summary
- make decimate_xy return contiguous arrays in early-return paths
- add regression tests for strided input views in short-circuit and NONE branches

## Why
Qt upload path expects contiguous buffers; short-circuit branches could return non-contiguous strided views.

Closes #38