### PR TITLE
Add File Open menu and shared startup open flow

### DIFF
--- a/tests/app_open_test.py
+++ b/tests/app_open_test.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from viewer.app_open import open_qraw_as_window
+
+
+class TestOpenQrawAsWindow(TestCase):
+
+    def test_open_qraw_as_window_returns_window_on_success(self):
+        # arrange
+        qraw_file = MagicMock()
+        created_window = MagicMock()
+        window_factory = MagicMock(return_value=created_window)
+        # act
+        with patch("viewer.app_open.QRawFile.load", return_value=qraw_file):
+            result = open_qraw_as_window("test.qraw", window_factory)
+        # assert
+        self.assertIs(result, created_window)
+        window_factory.assert_called_once_with(qraw_file)
+
+    def test_open_qraw_as_window_returns_none_on_parse_failure(self):
+        # arrange
+        window_factory = MagicMock()
+        # act
+        with patch("viewer.app_open.QRawFile.load", return_value=None):
+            result = open_qraw_as_window("bad.qraw", window_factory)
+        # assert
+        self.assertIsNone(result)
+        window_factory.assert_not_called()

--- a/tests/main_entry_test.py
+++ b/tests/main_entry_test.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+# mock PySide6 submodules before importing viewer.__main__, which requires Qt at import time
+sys.modules.setdefault("PySide6", MagicMock())
+sys.modules.setdefault("PySide6.QtCore", MagicMock())
+sys.modules.setdefault("PySide6.QtWidgets", MagicMock())
+
+
+class TestMainEntry(TestCase):
+
+    def test_main_gui_uses_shared_open_path(self):
+        # arrange
+        main_entry = importlib.import_module("viewer.__main__")
+        app = MagicMock()
+        app.exec.return_value = 0
+        icon = MagicMock()
+        icon.isNull.return_value = True
+        window = MagicMock()
+        # act
+        with patch.object(sys, "argv", ["viewer", "test.qraw"]), \
+             patch.object(main_entry, "QApplication", return_value=app), \
+             patch.object(main_entry, "load_app_icon", return_value=icon), \
+             patch.object(main_entry, "open_qraw_as_window", return_value=window) as mock_open:
+            with self.assertRaises(SystemExit) as exit_context:
+                main_entry.main()
+        # assert
+        self.assertEqual(exit_context.exception.code, 0)
+        mock_open.assert_called_once()
+        window.show.assert_called_once_with()
+        app.exec.assert_called_once_with()
+
+    def test_main_gui_exits_with_error_when_open_fails(self):
+        # arrange
+        main_entry = importlib.import_module("viewer.__main__")
+        app = MagicMock()
+        icon = MagicMock()
+        icon.isNull.return_value = True
+        # act
+        with patch.object(sys, "argv", ["viewer", "test.qraw"]), \
+             patch.object(main_entry, "QApplication", return_value=app), \
+             patch.object(main_entry, "load_app_icon", return_value=icon), \
+             patch.object(main_entry, "open_qraw_as_window", return_value=None) as mock_open:
+            with self.assertRaises(SystemExit) as exit_context:
+                main_entry.main()
+        # assert
+        self.assertEqual(exit_context.exception.code, 1)
+        mock_open.assert_called_once()
+        app.exec.assert_not_called()

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -361,6 +361,56 @@ class TestMainWindowSlots(TestCase):
         mock_register.assert_called_once_with(created_window)
         created_window.show.assert_called_once_with()
 
+    def test_menu_open_file_creates_secondary_main_window(self):
+        # arrange
+        win = self._make_win()
+        created_window = MagicMock()
+        # act
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/example.qraw", "QRAW Files (*.qraw)")), \
+             patch("viewer.main_window.open_qraw_as_window", return_value=created_window) as mock_open, \
+             patch("viewer.main_window._register_child_window") as mock_register:
+            win._on_menu_open_file()
+        # assert
+        mock_open.assert_called_once()
+        mock_register.assert_called_once_with(created_window)
+        created_window.show.assert_called_once_with()
+
+    def test_menu_open_file_canceled(self):
+        # arrange
+        win = self._make_win()
+        # act
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("", "QRAW Files (*.qraw)")), \
+             patch("viewer.main_window.open_qraw_as_window") as mock_open, \
+             patch("viewer.main_window._register_child_window") as mock_register:
+            win._on_menu_open_file()
+        # assert
+        mock_open.assert_not_called()
+        mock_register.assert_not_called()
+
+    def test_menu_open_file_load_failure(self):
+        # arrange
+        win = self._make_win()
+        # act
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/bad.qraw", "QRAW Files (*.qraw)")), \
+             patch("viewer.main_window.open_qraw_as_window", return_value=None) as mock_open, \
+             patch("viewer.main_window._register_child_window") as mock_register:
+            win._on_menu_open_file()
+        # assert
+        mock_open.assert_called_once()
+        mock_register.assert_not_called()
+
+    def test_menu_open_file_ignores_reentry_while_dialog_active(self):
+        # arrange
+        win = self._make_win()
+        # act
+        with patch("viewer.main_window._OPEN_FILE_DIALOG_ACTIVE", True), \
+             patch("viewer.main_window.QFileDialog.getOpenFileName") as mock_dialog, \
+             patch("viewer.main_window.open_qraw_as_window") as mock_open:
+            win._on_menu_open_file()
+        # assert
+        mock_dialog.assert_not_called()
+        mock_open.assert_not_called()
+
     def test_on_qml_ready_sets_step_tool_enabled_for_stepped_files(self):
         # arrange
         win = self._make_win()

--- a/viewer/__main__.py
+++ b/viewer/__main__.py
@@ -6,6 +6,7 @@ import warnings
 from PySide6.QtCore import QtMsgType, qInstallMessageHandler
 from PySide6.QtWidgets import QApplication, QFileDialog
 
+from viewer.app_open import open_qraw_as_window
 from viewer.main_window import load_app_icon, MainWindow
 from viewer.qraw_file import QRawFile
 
@@ -80,13 +81,11 @@ def main():
         # exit when the user cancels the dialog
         if not input_path:
             sys.exit(0)
-    # load and parse the QRAW file
-    qraw_file = QRawFile.load(input_path)
-    if qraw_file is None:
+    # load file and create the main window through shared open path
+    window = open_qraw_as_window(input_path, lambda qraw_file: MainWindow(qraw_file))
+    if window is None:
         # exit
         sys.exit(1)
-    # main window with the loaded QRAW file
-    window = MainWindow(qraw_file)
     # show the main window
     window.show()
     # enter the Qt application main loop

--- a/viewer/app_open.py
+++ b/viewer/app_open.py
@@ -1,0 +1,14 @@
+from collections.abc import Callable
+from pathlib import Path
+
+from .qraw_file import QRawFile
+
+
+def open_qraw_as_window(input_path: str | Path, window_factory: Callable[[QRawFile], object]) -> object | None:
+    # load and parse the QRAW file
+    qraw_file = QRawFile.load(input_path)
+    # return none when parsing fails
+    if qraw_file is None:
+        return None
+    # create the target window from the loaded qraw object
+    return window_factory(qraw_file)

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -6,9 +6,10 @@ import numpy as np
 from PySide6.QtCore import QSize, QTimer, QUrl, Slot
 from PySide6.QtGui import QAction, QColor, QGuiApplication, QIcon, QKeySequence
 from PySide6.QtQuick import QQuickView
-from PySide6.QtWidgets import QMainWindow, QWidget
+from PySide6.QtWidgets import QFileDialog, QMainWindow, QWidget
 
 from .add_plot_dialog import AddPlotDialog
+from .app_open import open_qraw_as_window
 from .chart import Chart
 from .expression import Expression
 from .expression_manager import ExpressionManager
@@ -38,6 +39,9 @@ _MIN_STATUS_INTERVAL = 1.0 / 30
 # application-level registry keeps child windows alive independently
 # of the source main window that created them
 _CHILD_WINDOWS: set[QMainWindow] = set()
+
+# application-level open-file dialog lock prevents stacked dialogs
+_OPEN_FILE_DIALOG_ACTIVE = False
 
 
 def _register_child_window(window: QMainWindow) -> None:
@@ -270,6 +274,13 @@ class MainWindow(QMainWindow):
 
         # File menu
         file_menu = menu_bar.addMenu("&File")
+
+        # File | Open
+        open_action = QAction("Open...", self)
+        open_action.setShortcut(QKeySequence.Open)
+        open_action.triggered.connect(self._on_menu_open_file)
+        file_menu.addAction(open_action)
+
         # File | Quit
         quit_action = QAction("Quit", self)
         quit_action.setShortcut(QKeySequence.Quit)
@@ -490,6 +501,31 @@ class MainWindow(QMainWindow):
         logger.debug("User requested opening a new window")
         # create a new independent main window sharing the same source data and path
         new_window = MainWindow(self._qraw_file, source_qraw_path=self._qraw_path, start_empty=True)
+        # keep reference alive independently of the source main window
+        _register_child_window(new_window)
+        # show the new window
+        new_window.show()
+
+    @Slot()
+    def _on_menu_open_file(self) -> None:
+        # use application-level lock so only one open-file dialog can exist at a time
+        global _OPEN_FILE_DIALOG_ACTIVE
+        if _OPEN_FILE_DIALOG_ACTIVE:
+            return
+        _OPEN_FILE_DIALOG_ACTIVE = True
+        # prompt for a file
+        try:
+            input_path, _ = QFileDialog.getOpenFileName(self, "Open QRAW File", "", "QRAW Files (*.qraw);;All Files (*)")
+        finally:
+            _OPEN_FILE_DIALOG_ACTIVE = False
+        # exit when the user cancels the dialog
+        if not input_path:
+            return
+        # load file and create a new main window through shared open path
+        new_window = open_qraw_as_window(input_path, lambda qraw_file: MainWindow(qraw_file))
+        # exit when the file fails to load
+        if new_window is None:
+            return
         # keep reference alive independently of the source main window
         _register_child_window(new_window)
         # show the new window


### PR DESCRIPTION
## Summary
- add File | Open menu action to open qraw in a new window
- extract shared open/load helper used by startup and menu flow
- prevent stacked open dialogs with a global dialog-active guard
- add regression tests for menu open behavior and startup path

## Validation
- python -m unittest tests/main_window_test.py
- python -m unittest discover -s tests -p '*_test.py'

Closes #62