### PR TITLE
Refactor stepped handling for variable-length abscissa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,13 @@ coverage.xml
 
 .env*
 .venv*
+
+# local raw-data artifacts
+/Ladder.qraw
+/MiddleBrook.qraw
+/Noise.qraw
+/NoiseFigure.qraw
+/PLL.qraw
+/test-2.fft.qraw
+/test-2.qraw
+/test.qraw

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,8 @@
     "git add": true,
     "git commit": true,
     "git push": true,
-    "git switch": true
+    "git switch": true,
+    "/Users/rogelio/Projects/qspice-qraw-viewer/.venv/bin/python": true,
+    "exit": true
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,6 +17,7 @@
     "git push": true,
     "git switch": true,
     "/Users/rogelio/Projects/qspice-qraw-viewer/.venv/bin/python": true,
-    "exit": true
+    "exit": true,
+    ".venv/bin/python": true
   }
 }

--- a/tests/app_open_test.py
+++ b/tests/app_open_test.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from viewer.app_open import open_qraw_as_window
+
+
+class TestOpenQrawAsWindow(TestCase):
+
+    def test_open_qraw_as_window_returns_window_on_success(self):
+        # arrange
+        qraw_file = MagicMock()
+        created_window = MagicMock()
+        window_factory = MagicMock(return_value=created_window)
+        # act
+        with patch("viewer.app_open.QRawFile.load", return_value=qraw_file):
+            result = open_qraw_as_window("test.qraw", window_factory)
+        # assert
+        self.assertIs(result, created_window)
+        window_factory.assert_called_once_with(qraw_file)
+
+    def test_open_qraw_as_window_returns_none_on_parse_failure(self):
+        # arrange
+        window_factory = MagicMock()
+        # act
+        with patch("viewer.app_open.QRawFile.load", return_value=None):
+            result = open_qraw_as_window("bad.qraw", window_factory)
+        # assert
+        self.assertIsNone(result)
+        window_factory.assert_not_called()

--- a/tests/chart_test.py
+++ b/tests/chart_test.py
@@ -12,6 +12,20 @@ sys.modules.setdefault("PySide6.QtQuick", MagicMock())
 
 from viewer.chart import Chart  # noqa: E402
 from viewer.expression import Expression  # noqa: E402
+from viewer.qraw_file import StepInformation  # noqa: E402
+
+
+def _make_step_information(num_steps: int, abscissa_length: int, ascending: bool = True) -> StepInformation:
+    # helper to create StepInformation for tests
+    step_size = abscissa_length // num_steps if num_steps > 0 else abscissa_length
+    keys = ["step"]
+    values = [(i,) for i in range(num_steps)]
+    abscissa_indices = [slice(i * step_size, (i + 1) * step_size) for i in range(num_steps)]
+    if ascending:
+        abscissa_value_ranges = [(float(i * step_size), float((i + 1) * step_size)) for i in range(num_steps)]
+    else:
+        abscissa_value_ranges = [(float((i + 1) * step_size), float(i * step_size)) for i in range(num_steps)]
+    return StepInformation(keys, values, abscissa_indices, abscissa_value_ranges)
 
 
 class TestChart(TestCase):
@@ -21,17 +35,19 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
+        step_information = _make_step_information(1, 100)
         # act
-        chart = Chart(component, "AC", MagicMock(), abscissa, 10, 90, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, step_information, 500)
         # assert
-        self.assertEqual(chart._zoom_window, (10, 0.0, 90, 1.0))
+        self.assertEqual(chart._zoom_window, (None, None, None, None))
 
     def test_expressions_initially_empty(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        step_information = _make_step_information(1, 100)
+        chart = Chart(component, "AC", MagicMock(), abscissa, step_information, 500)
         # act
         result = chart.expressions
         # assert
@@ -42,7 +58,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
         result = chart.expressions
         result.append(MagicMock())
@@ -54,7 +70,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
         chart.auto_range()
         # assert — no axis interaction when there are no series
@@ -65,7 +81,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         chart.plot_series = MagicMock()
         # act
         chart.selected_steps = {0}
@@ -77,7 +93,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         # act
         selected_steps = chart.selected_steps
         # assert
@@ -88,7 +104,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         chart.plot_series = MagicMock()
         # act
         chart.selected_steps = set()
@@ -100,7 +116,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         mock_y_axis = MagicMock()
         vout = Expression("Vout", np.array([1.0, 2.0]), "V")
         # manually inject a series entry with known min/max so auto_range is predictable
@@ -115,13 +131,13 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         mock_y_axis = MagicMock()
         vout = Expression("Vout", np.array([1.0, 2.0]), "V")
         # inject a series with min=-1.0 and max=5.0 (range of 6.0)
         chart._series = {"Vout": (vout, {vout: (mock_y_axis, {}, -1.0, 5.0, "#f77f00")})}
         # apply a vertical zoom that selects only the top quarter (0.0 to 0.25)
-        chart.update_zoom_window(-1, -1, 0.0, 0.25)
+        chart.update_zoom_window(None, None, 0.0, 0.25)
         # act
         chart.auto_range()
         # assert — autorange uses series min/max and applies 3% padding
@@ -132,13 +148,13 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
-        # act — negative x indices signal "no horizontal change"
-        chart.update_zoom_window(-1, -1, 0.25, 0.75)
-        # assert — only vertical slice of zoom window changed
-        self.assertEqual(chart._zoom_window[0], 0)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
+        # act — None x signals "no horizontal change"
+        chart.update_zoom_window(None, None, 0.25, 0.75)
+        # assert — only vertical slice of zoom window changed, horizontal remains None
+        self.assertIsNone(chart._zoom_window[0])
         self.assertAlmostEqual(chart._zoom_window[1], 0.25)
-        self.assertEqual(chart._zoom_window[2], 100)
+        self.assertIsNone(chart._zoom_window[2])
         self.assertAlmostEqual(chart._zoom_window[3], 0.75)
 
     def test_update_zoom_window_horizontal_only(self):
@@ -146,24 +162,24 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act — None signals "no vertical change"
-        chart.update_zoom_window(10, 80, None, None)
-        # assert — only horizontal slice of zoom window changed
-        self.assertEqual(chart._zoom_window[0], 10)
-        self.assertAlmostEqual(chart._zoom_window[1], 0.0)
-        self.assertEqual(chart._zoom_window[2], 80)
-        self.assertAlmostEqual(chart._zoom_window[3], 1.0)
+        chart.update_zoom_window(0.1, 0.8, None, None)
+        # assert — only horizontal slice of zoom window changed, vertical remains None
+        self.assertAlmostEqual(chart._zoom_window[0], 0.1)
+        self.assertIsNone(chart._zoom_window[1])
+        self.assertAlmostEqual(chart._zoom_window[2], 0.8)
+        self.assertIsNone(chart._zoom_window[3])
 
     def test_update_zoom_window_vertical_zoom_composition(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act — apply two consecutive vertical zooms, each selecting the lower half
-        chart.update_zoom_window(-1, -1, 0.0, 0.5)
-        chart.update_zoom_window(-1, -1, 0.0, 0.5)
+        chart.update_zoom_window(None, None, 0.0, 0.5)
+        chart.update_zoom_window(None, None, 0.0, 0.5)
         # assert — second zoom compounds on the first: upper bound goes from 0.5 to 0.25
         self.assertAlmostEqual(chart._zoom_window[1], 0.0)
         self.assertAlmostEqual(chart._zoom_window[3], 0.25)
@@ -173,9 +189,9 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
-        chart.reset_zoom_window(-1, -1, 0.1, 0.9)
+        chart.update_zoom_window(None, None, 0.1, 0.9)
         # assert — zoom window reflects the provided ratios directly (no composition)
         self.assertAlmostEqual(chart._zoom_window[1], 0.1)
         self.assertAlmostEqual(chart._zoom_window[3], 0.9)
@@ -185,9 +201,9 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act — reset to the default values that are already in place
-        chart.reset_zoom_window(-1, -1, 0.0, 1.0)
+        chart.update_zoom_window(None, None, 0.0, 1.0)
         # assert — zoom window unchanged since new values match existing ones
         self.assertAlmostEqual(chart._zoom_window[1], 0.0)
         self.assertAlmostEqual(chart._zoom_window[3], 1.0)
@@ -197,21 +213,23 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
-        # act
-        chart.reset_zoom_window(20, 70, None, None)
-        # assert — horizontal indices updated, vertical unchanged
-        self.assertEqual(chart._zoom_window[0], 20)
-        self.assertAlmostEqual(chart._zoom_window[1], 0.0)
-        self.assertEqual(chart._zoom_window[2], 70)
-        self.assertAlmostEqual(chart._zoom_window[3], 1.0)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
+        # first zoom in horizontally
+        chart.update_zoom_window(0.2, 0.7, None, None)
+        # act — reset horizontal zoom only
+        chart.reset_zoom_window(True, False)
+        # assert — horizontal reset to None, vertical unchanged
+        self.assertIsNone(chart._zoom_window[0])
+        self.assertIsNone(chart._zoom_window[1])
+        self.assertIsNone(chart._zoom_window[2])
+        self.assertIsNone(chart._zoom_window[3])
 
     def test_get_y_axis_creates_axis_for_new_expression_type(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
         axis = chart._get_y_axis("V")
         # assert
@@ -223,7 +241,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         axis_first = chart._get_y_axis("V")
         # act — request the same expression type a second time
         axis_second = chart._get_y_axis("V")
@@ -236,7 +254,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # fill up all four allowed Y axes with distinct expression types
         chart._get_y_axis("V")
         chart._get_y_axis("A")
@@ -252,7 +270,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         vout = Expression("Vout", np.array([1.0, 2.0]), "V")
         # inject state that clear() must wipe
         chart._y_axes["V"] = MagicMock()
@@ -269,24 +287,24 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # zoom in horizontally and vertically before clearing
-        chart.update_zoom_window(20, 80, None, None)
-        chart.update_zoom_window(-1, -1, 0.2, 0.8)
+        chart.update_zoom_window(0.2, 0.8, None, None)
+        chart.update_zoom_window(None, None, 0.2, 0.8)
         # act
         chart.clear()
-        # assert — vertical zoom is reset to defaults; horizontal range is preserved
-        self.assertEqual(chart._zoom_window[0], 20)
-        self.assertAlmostEqual(chart._zoom_window[1], 0.0)
-        self.assertEqual(chart._zoom_window[2], 80)
-        self.assertAlmostEqual(chart._zoom_window[3], 1.0)
+        # assert — vertical zoom is reset to None; horizontal range is preserved
+        self.assertAlmostEqual(chart._zoom_window[0], 0.2)
+        self.assertIsNone(chart._zoom_window[1])
+        self.assertAlmostEqual(chart._zoom_window[2], 0.8)
+        self.assertIsNone(chart._zoom_window[3])
 
     def test_ordinate_values_at_abscissa_value_returns_empty_when_no_series(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
         result = chart.ordinate_values_at_abscissa_value(0.5)
         # assert
@@ -296,12 +314,12 @@ class TestChart(TestCase):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 1.0, 11), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 11, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 11), 500)
         # ordinate: 11 linearly-spaced values from 0 to 100
         vout = Expression("Vout", np.linspace(0.0, 100.0, 11), "V")
         mock_y_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_y_axis, {0: MagicMock()}, 0.0, 100.0, "#f77f00")})
-        # act — sample at the right edge (x_ratio=1.0) should return the last value
+        # act — sample at the rightmost abscissa value (1.0) should return the last ordinate
         result = chart.ordinate_values_at_abscissa_value(1.0)
         # assert
         self.assertEqual(len(result), 1)
@@ -314,67 +332,40 @@ class TestChart(TestCase):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 11, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 11), 500)
         # ordinate: index-valued array so we can easily verify which index was sampled
         vout = Expression("Vout", np.arange(11, dtype=float), "V")
         mock_y_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_y_axis, {0: MagicMock()}, 0.0, 10.0, "#f77f00")})
-        # act — x_ratio maps to the middle x-value of the visible window
-        result = chart.ordinate_values_at_abscissa_value(0.5)
+        # act — x_value=5.0 is the midpoint of abscissa [0, 10]
+        result = chart.ordinate_values_at_abscissa_value(5.0)
         # assert — nearest sample to the midpoint
         _, _, values = result[0]
         self.assertEqual(values, [5.0])
 
-    def test_ordinate_values_at_abscissa_value_clamps_to_zoom_window(self):
+    def test_ordinate_values_at_abscissa_value_finds_nearest_sample(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 2, 8, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 11), 500)
         vout = Expression("Vout", np.arange(11, dtype=float), "V")
         mock_y_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_y_axis, {0: MagicMock()}, 0.0, 10.0, "#f77f00")})
-        # act — x_ratio=0.0 must map to from_index=2, not index 0
+        # act — x_value=0.0 is the leftmost point
         result_left = chart.ordinate_values_at_abscissa_value(0.0)
-        # x_ratio=1.0 must map to to_index-1=7
-        result_right = chart.ordinate_values_at_abscissa_value(1.0)
+        # x_value=10.0 is the rightmost point
+        result_right = chart.ordinate_values_at_abscissa_value(10.0)
         # assert
         _, _, left_val = result_left[0]
         _, _, right_val = result_right[0]
-        self.assertEqual(left_val, [2.0])
-        self.assertEqual(right_val, [7.0])
-
-    def test_ordinate_values_at_abscissa_value_returns_empty_for_empty_visible_window_even_with_series(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 1, 1, 1, 500)
-        vout = Expression("Vout", np.array([10.0, 20.0, 30.0]), "V")
-        mock_axis = MagicMock()
-        chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 10.0, 30.0, "#f77f00")})
-        # act
-        result = chart.ordinate_values_at_abscissa_value(0.5)
-        # assert
-        self.assertEqual(result, [])
-
-    def test_ordinate_values_at_abscissa_value_falls_back_to_raw_when_cached_points_are_empty(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0, 3.0]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 4, 1, 500)
-        vout = Expression("Vout", np.array([10.0, 20.0, 30.0, 40.0]), "V")
-        mock_axis = MagicMock()
-        chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 10.0, 40.0, "#f77f00")})
-        chart._sample_cache[vout] = {0: (np.array([]), np.array([]))}
-        # act
-        result = chart.ordinate_values_at_abscissa_value(0.5)
-        # assert
-        self.assertEqual(result, [("Vout", "V", [20.0])])
+        self.assertEqual(left_val, [0.0])
+        self.assertEqual(right_val, [10.0])
 
     def test_ordinate_values_at_abscissa_value_multiple_series(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 1.0, 5), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 5, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 5), 500)
         vout = Expression("Vout", np.array([10.0, 20.0, 30.0, 40.0, 50.0]), "V")
         iout = Expression("Iout", np.array([1.0, 2.0, 3.0, 4.0, 5.0]), "A")
         mock_axis = MagicMock()
@@ -388,45 +379,12 @@ class TestChart(TestCase):
         self.assertIn("Vout", names)
         self.assertIn("Iout", names)
 
-    def test_plot_series_removes_unselected_steps_and_clears_cached_points(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0, 3.0]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 4, 2, 500)
-        chart._selected_steps = set()
-        vout = Expression("Vout", np.array([1.0, 2.0, 3.0, 4.0, 11.0, 12.0, 13.0, 14.0]), "V")
-        rendered_series = {1: MagicMock()}
-        mock_axis = MagicMock()
-        chart._series["Vout"] = (vout, {vout: (mock_axis, rendered_series, 1.0, 14.0, "#f77f00")})
-        chart._sample_cache[vout] = {1: (np.array([0.0]), np.array([1.0]))}
-        # act
-        chart.plot_series({vout})
-        # assert
-        self.assertEqual(rendered_series, {})
-        self.assertEqual(chart._sample_cache[vout], {})
-
-    def test_plot_series_skips_step_when_decimated_values_are_non_finite(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0, 3.0]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 4, 1, 500)
-        vout = Expression("Vout", np.array([1.0, 2.0, 3.0, 4.0]), "V")
-        # act
-        with patch("viewer.chart.decimate_xy", return_value=(np.array([0.0, 1.0]), np.array([np.nan, np.inf]))):
-            chart.plot_series({vout})
-        # assert
-        self.assertIn("Vout", chart._series)
-        _, ordinate_series = chart._series["Vout"]
-        _, rendered_series, _, _, _ = ordinate_series[vout]
-        self.assertEqual(rendered_series, {})
-        self.assertNotIn(vout, chart._sample_cache)
-
     def test_release_y_axis_clears_right_primary_reference(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         axis = MagicMock()
         axis.property.return_value = "V"
         chart._right_y_axis_1 = axis
@@ -443,7 +401,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         axis = MagicMock()
         axis.property.return_value = "A"
         chart._left_y_axis_2 = axis
@@ -460,7 +418,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         axis = MagicMock()
         axis.property.return_value = "W"
         chart._right_y_axis_2 = axis
@@ -472,31 +430,12 @@ class TestChart(TestCase):
         self.assertTrue(removed)
         self.assertIsNone(chart._right_y_axis_2)
 
-    def test_ordinate_values_at_abscissa_value_prefers_rendered_decimated_points_over_raw_samples(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 11, 1, 500)
-        # raw data has a narrow spike at x=5 that may be absent from rendered decimated points
-        vout = Expression("Vout", np.array([0.0, 0.5, 1.0, 2.0, 3.2, 4.2, 3.1, 2.0, 1.0, 0.5, 0.0]), "V")
-        mock_axis = MagicMock()
-        chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 0.0, 4.2, "#f77f00")})
-        # rendered decimated points shown on chart near the same x do not include the raw spike
-        chart._sample_cache[vout] = {0: (np.array([0.0, 5.0, 10.0]), np.array([0.0, 3.9, 0.0]))}
-        # act
-        result = chart.ordinate_values_at_abscissa_value(0.5)
-        # assert
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0][0], "Vout")
-        self.assertEqual(result[0][1], "V")
-        self.assertEqual(result[0][2], [3.9])
-
     def test_abscissa_property(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
         result = chart.abscissa
         # assert
@@ -507,18 +446,19 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 10.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        step_information = StepInformation(["step"], [(0,)], [slice(0, 100)], [(0.0, 10.0)])
+        chart = Chart(component, "AC", MagicMock(), abscissa, step_information, 500)
         # act
         chart.render("Time", "linear", set())
         # assert — initialize must receive label, unit, scale, and exact boundary values
-        component.initialize.assert_called_once_with("Time", "s", "linear", float(values[0]), float(values[99]))
+        component.initialize.assert_called_once_with("Time", "s", "linear", 0.0, 10.0)
 
     def test_render_calls_auto_range_after_plot_series(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 10.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
         with patch.object(chart, "auto_range") as mock_auto_range:
             chart.render("Time", "linear", set())
@@ -530,7 +470,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         decimated_x = np.linspace(0.0, 1.0, 10)
         decimated_y = np.linspace(0.0, 5.0, 10)
@@ -545,7 +485,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         decimated_x = np.linspace(0.0, 1.0, 10)
         decimated_y = np.linspace(0.0, 5.0, 10)
@@ -560,7 +500,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         decimated_x = np.linspace(0.0, 1.0, 10)
         decimated_y = np.linspace(0.0, 5.0, 10)
@@ -575,7 +515,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         # inject existing series entry so chart believes Vout is already plotted
         chart._series["Vout"] = (vout, {vout: (MagicMock(), {0: MagicMock()}, 0.0, 5.0, "#f77f00")})
@@ -589,7 +529,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         y_axis = MagicMock()
         y_axis.property.return_value = "V"
@@ -613,7 +553,7 @@ class TestChart(TestCase):
         abscissa = Expression("Time", values, "s")
         # two steps: 20 ordinate points total (10 per step)
         ordinate_data = np.linspace(0.0, 5.0, 2 * n)
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, n, 2, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(2, n), 500)
         vout = Expression("Vout", ordinate_data, "V")
         decimated_y = np.linspace(0.0, 5.0, n)
         # act
@@ -629,7 +569,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         # act
         result = chart._get_expressions_to_plot(vout)
@@ -645,7 +585,7 @@ class TestChart(TestCase):
         magnitude_expr = Expression("db(Vout)", np.ones(10), "dB")
         phase_expr = Expression("phase(Vout)", np.zeros(10), "deg")
         mock_manager.evaluate.side_effect = lambda expr: magnitude_expr if expr == "db(Vout)" else phase_expr
-        chart = Chart(component, "AC", mock_manager, abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", mock_manager, abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.ones(10, dtype=np.complex128), "V")
         # act
         result = chart._get_expressions_to_plot(vout)
@@ -664,7 +604,7 @@ class TestChart(TestCase):
         mock_manager = MagicMock()
         # evaluate always returns None — magnitude lookup fails immediately
         mock_manager.evaluate.return_value = None
-        chart = Chart(component, "AC", mock_manager, abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", mock_manager, abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.ones(10, dtype=np.complex128), "V")
         # act
         result = chart._get_expressions_to_plot(vout)
@@ -680,7 +620,7 @@ class TestChart(TestCase):
         magnitude_expr = Expression("db(Vout)", np.ones(10), "dB")
         # magnitude succeeds but phase lookup fails
         mock_manager.evaluate.side_effect = lambda expr: magnitude_expr if expr == "db(Vout)" else None
-        chart = Chart(component, "AC", mock_manager, abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", mock_manager, abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.ones(10, dtype=np.complex128), "V")
         # act
         result = chart._get_expressions_to_plot(vout)
@@ -691,7 +631,7 @@ class TestChart(TestCase):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 1e-3, 10), "s")
-        chart = Chart(component, "TRAN", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "TRAN", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.ones(10, dtype=np.complex128), "V")
         # act
         result = chart._get_expressions_to_plot(vout)
@@ -702,7 +642,7 @@ class TestChart(TestCase):
         # arrange
         component = MagicMock()
         abscissa = Expression("V1", np.linspace(0.0, 5.0, 10), "V")
-        chart = Chart(component, "DC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "DC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.ones(10, dtype=np.complex128), "V")
         # act
         result = chart._get_expressions_to_plot(vout)
@@ -714,7 +654,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         chart._left_y_axis_1 = MagicMock()
         chart._right_y_axis_1 = MagicMock()
         chart._left_y_axis_2 = MagicMock()
@@ -732,7 +672,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         axis = MagicMock()
         axis.property.return_value = "V"
         chart._left_y_axis_1 = axis
@@ -750,7 +690,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         axis = MagicMock()
         axis.property.return_value = "V"
         chart._left_y_axis_1 = axis
@@ -769,7 +709,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         decimated_x = np.linspace(0.0, 1.0, 10)
         decimated_y = np.linspace(0.0, 5.0, 10)
@@ -787,7 +727,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         decimated_x = np.linspace(0.0, 1.0, 10)
         decimated_y = np.linspace(0.0, 5.0, 10)
@@ -804,7 +744,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 10.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         mock_series = MagicMock()
         chart._series["Vout"] = (vout, {vout: (MagicMock(), {0: mock_series}, 0.0, 5.0, "#f77f00")})
@@ -820,7 +760,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 10.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
         mock_series = MagicMock()
         chart._series["Vout"] = (vout, {vout: (MagicMock(), {0: mock_series}, 0.0, 5.0, "#f77f00")})
@@ -837,64 +777,70 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         # act
         with patch.object(chart, "_redraw_all_series") as mock_redraw:
             chart.update_zoom_window(10, 80, None, None)
         # assert
         mock_redraw.assert_called_once()
 
-    def test_update_zoom_window_both_calls_redraw_and_auto_range(self):
+    def test_update_zoom_window_both_calls_redraw_and_updates_axes(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
+        mock_y_axis = MagicMock()
+        chart._axis_ranges = {mock_y_axis: (0.0, 10.0)}
         # act — both horizontal and vertical changes supplied simultaneously
         with patch.object(chart, "_redraw_all_series") as mock_redraw:
-            with patch.object(chart, "auto_range") as mock_auto_range:
-                chart.update_zoom_window(10, 80, 0.25, 0.75)
-        # assert
+            chart.update_zoom_window(0.1, 0.8, 0.25, 0.75)
+        # assert — horizontal triggers redraw, vertical updates axes directly
         mock_redraw.assert_called_once()
-        mock_auto_range.assert_called_once()
+        mock_y_axis.setRange.assert_called_once()
 
     def test_update_zoom_window_vertical_only_updates_axis_ranges(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         mock_y_axis = MagicMock()
         # inject known axis range so the zoom calculation is predictable
         chart._axis_ranges = {mock_y_axis: (0.0, 10.0)}
         # act — select bottom half (ratios 0.5 → 1.0)
-        chart.update_zoom_window(-1, -1, 0.5, 1.0)
-        # assert — setRange called with 0+0.5*10=5.0 and 0+1.0*10=10.0
-        mock_y_axis.setRange.assert_called_once_with(5.0, 10.0)
+        chart.update_zoom_window(None, None, 0.5, 1.0)
+        # assert — visual range is [-0.3, 10.3] (3% padding); bottom half selected
+        call_args = mock_y_axis.setRange.call_args.args
+        self.assertAlmostEqual(call_args[0], 5.0, places=5)
+        self.assertAlmostEqual(call_args[1], 10.3, places=5)
 
     def test_reset_zoom_window_vertical_changed_updates_axis_ranges(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         mock_y_axis = MagicMock()
         chart._axis_ranges = {mock_y_axis: (0.0, 10.0)}
-        # act — reset to ratios different from the default (0.0, 1.0) triggers axis update
-        chart.reset_zoom_window(-1, -1, 0.3, 0.7)
-        # assert — setRange called with raw stored min/max values
-        mock_y_axis.setRange.assert_called_once_with(0.0, 10.0)
+        # first zoom in vertically so that reset changes the state
+        chart.update_zoom_window(None, None, 0.2, 0.8)
+        mock_y_axis.setRange.reset_mock()
+        # act — reset vertical zoom
+        chart.reset_zoom_window(False, True)
+        # assert — reset calls setRange with padded full range
+        mock_y_axis.setRange.assert_called_once_with(-0.3, 10.3)
 
     def test_reset_zoom_window_no_axis_update_when_vertical_unchanged(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 100), 500)
         mock_y_axis = MagicMock()
         chart._axis_ranges = {mock_y_axis: (0.0, 10.0)}
-        # act — same ratios already stored — no change detected
-        chart.reset_zoom_window(-1, -1, 0.0, 1.0)
+        # act — reset horizontal only, no vertical change
+        chart.reset_zoom_window(True, False)
         # assert — setRange must not be called when vertical zoom did not change
         mock_y_axis.setRange.assert_not_called()
 
@@ -903,7 +849,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.full(10, 3.0), "V")
         decimated_y = np.full(10, 3.0)
         # act
@@ -921,7 +867,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.zeros(10), "V")
         decimated_y = np.zeros(10)
         # act
@@ -939,7 +885,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 10.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         vout = Expression("Vout", np.full(10, 7.0), "V")
         mock_series = MagicMock()
         chart._series["Vout"] = (vout, {vout: (MagicMock(), {0: mock_series}, 7.0, 7.0, "#f77f00")})
@@ -956,7 +902,7 @@ class TestChart(TestCase):
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 10)
         abscissa = Expression("Time", values, "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 10, 1, 500)
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
         # occupy all four axis slots so the fifth unit returns None from _get_y_axis
         chart._get_y_axis("V")
         chart._get_y_axis("A")

--- a/tests/chart_test.py
+++ b/tests/chart_test.py
@@ -281,18 +281,18 @@ class TestChart(TestCase):
         self.assertEqual(chart._zoom_window[2], 80)
         self.assertAlmostEqual(chart._zoom_window[3], 1.0)
 
-    def test_sample_at_returns_empty_when_no_series(self):
+    def test_ordinate_values_at_abscissa_value_returns_empty_when_no_series(self):
         # arrange
         component = MagicMock()
         values = np.linspace(0.0, 1.0, 100)
         abscissa = Expression("Time", values, "s")
         chart = Chart(component, "AC", MagicMock(), abscissa, 0, 100, 1, 500)
         # act
-        result = chart.sample_at(0.5)
+        result = chart.ordinate_values_at_abscissa_value(0.5)
         # assert
         self.assertEqual(result, [])
 
-    def test_sample_at_returns_name_unit_value_for_plotted_series(self):
+    def test_ordinate_values_at_abscissa_value_returns_name_unit_value_for_plotted_series(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 1.0, 11), "s")
@@ -302,7 +302,7 @@ class TestChart(TestCase):
         mock_y_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_y_axis, {0: MagicMock()}, 0.0, 100.0, "#f77f00")})
         # act — sample at the right edge (x_ratio=1.0) should return the last value
-        result = chart.sample_at(1.0)
+        result = chart.ordinate_values_at_abscissa_value(1.0)
         # assert
         self.assertEqual(len(result), 1)
         name, unit, values = result[0]
@@ -310,7 +310,7 @@ class TestChart(TestCase):
         self.assertEqual(unit, "V")
         self.assertEqual(values, [100.0])
 
-    def test_sample_at_nearest_sample_at_midpoint(self):
+    def test_ordinate_values_at_abscissa_value_nearest_ordinate_values_at_abscissa_value_midpoint(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
@@ -320,12 +320,12 @@ class TestChart(TestCase):
         mock_y_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_y_axis, {0: MagicMock()}, 0.0, 10.0, "#f77f00")})
         # act — x_ratio maps to the middle x-value of the visible window
-        result = chart.sample_at(0.5)
+        result = chart.ordinate_values_at_abscissa_value(0.5)
         # assert — nearest sample to the midpoint
         _, _, values = result[0]
         self.assertEqual(values, [5.0])
 
-    def test_sample_at_clamps_to_zoom_window(self):
+    def test_ordinate_values_at_abscissa_value_clamps_to_zoom_window(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
@@ -334,112 +334,16 @@ class TestChart(TestCase):
         mock_y_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_y_axis, {0: MagicMock()}, 0.0, 10.0, "#f77f00")})
         # act — x_ratio=0.0 must map to from_index=2, not index 0
-        result_left = chart.sample_at(0.0)
+        result_left = chart.ordinate_values_at_abscissa_value(0.0)
         # x_ratio=1.0 must map to to_index-1=7
-        result_right = chart.sample_at(1.0)
+        result_right = chart.ordinate_values_at_abscissa_value(1.0)
         # assert
         _, _, left_val = result_left[0]
         _, _, right_val = result_right[0]
         self.assertEqual(left_val, [2.0])
         self.assertEqual(right_val, [7.0])
 
-    def test_zoom_abscissa_bounds_returns_current_horizontal_window(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 2, 8, 1, 500)
-        # act
-        from_index, to_index = chart.zoom_abscissa_bounds()
-        # assert
-        self.assertEqual(from_index, 2)
-        self.assertEqual(to_index, 8)
-
-    def test_sample_index_at_ratio_clamps_to_zoom_bounds(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 2, 8, 1, 500)
-        # act
-        left_index = chart.sample_index_at_ratio(-0.5)
-        right_index = chart.sample_index_at_ratio(2.0)
-        # assert
-        self.assertEqual(left_index, 2)
-        self.assertEqual(right_index, 7)
-
-    def test_sample_index_at_ratio_uses_nearest_sample_in_window(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 11, 1, 500)
-        # act
-        index = chart.sample_index_at_ratio(0.5)
-        # assert
-        self.assertEqual(index, 5)
-
-    def test_sample_index_at_ratio_uses_nearest_x_on_non_uniform_abscissa(self):
-        # arrange
-        component = MagicMock()
-        # non-uniform transient-like spacing with dense early samples
-        abscissa = Expression("Time", np.array([0.0, 1e-9, 2e-9, 3e-9, 4e-9, 1e-3, 2e-3, 3e-3]), "s")
-        chart = Chart(component, "TRANSIENT", MagicMock(), abscissa, 0, 8, 1, 500)
-        # act — middle of visible x-range is 1.5 ms, equidistant from 1 ms and 2 ms; ties choose the left sample
-        index = chart.sample_index_at_ratio(0.5)
-        # assert
-        self.assertEqual(index, 5)
-
-    def test_sample_index_at_ratio_single_point_window_returns_from_index(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.array([0.0, 1.0, 2.0]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 1, 2, 1, 500)
-        # act
-        index = chart.sample_index_at_ratio(0.8)
-        # assert
-        self.assertEqual(index, 1)
-
-    def test_sample_index_at_ratio_descending_window_clamps_right_bound(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.array([3.0, 2.0, 1.0]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
-        # act
-        index = chart.sample_index_at_ratio(1.0)
-        # assert
-        self.assertEqual(index, 2)
-
-    def test_sample_index_at_ratio_descending_window_uses_nearest_x(self):
-        # arrange
-        component = MagicMock()
-        abscissa = Expression("Time", np.array([3.0, 2.0, 1.0]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
-        # act
-        index = chart.sample_index_at_ratio(0.5)
-        # assert
-        self.assertEqual(index, 1)
-
-    def test_sample_index_at_ratio_ascending_clamps_right_bound_for_nan_target(self):
-        # arrange
-        component = MagicMock()
-        # crafted values produce a NaN target at x_ratio=1.0 via inf arithmetic
-        abscissa = Expression("Time", np.array([-np.inf, 0.0, np.inf]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
-        # act
-        index = chart.sample_index_at_ratio(1.0)
-        # assert
-        self.assertEqual(index, 2)
-
-    def test_sample_index_at_ratio_descending_clamps_left_bound_for_nan_target(self):
-        # arrange
-        component = MagicMock()
-        # crafted values produce a NaN target at x_ratio=1.0 via inf arithmetic
-        abscissa = Expression("Time", np.array([np.inf, 0.0, -np.inf]), "s")
-        chart = Chart(component, "AC", MagicMock(), abscissa, 0, 3, 1, 500)
-        # act
-        index = chart.sample_index_at_ratio(1.0)
-        # assert
-        self.assertEqual(index, 0)
-
-    def test_sample_at_returns_empty_for_empty_visible_window_even_with_series(self):
+    def test_ordinate_values_at_abscissa_value_returns_empty_for_empty_visible_window_even_with_series(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.array([0.0, 1.0, 2.0]), "s")
@@ -448,11 +352,11 @@ class TestChart(TestCase):
         mock_axis = MagicMock()
         chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 10.0, 30.0, "#f77f00")})
         # act
-        result = chart.sample_at(0.5)
+        result = chart.ordinate_values_at_abscissa_value(0.5)
         # assert
         self.assertEqual(result, [])
 
-    def test_sample_at_falls_back_to_raw_when_cached_points_are_empty(self):
+    def test_ordinate_values_at_abscissa_value_falls_back_to_raw_when_cached_points_are_empty(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.array([0.0, 1.0, 2.0, 3.0]), "s")
@@ -462,11 +366,11 @@ class TestChart(TestCase):
         chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 10.0, 40.0, "#f77f00")})
         chart._sample_cache[vout] = {0: (np.array([]), np.array([]))}
         # act
-        result = chart.sample_at(0.5)
+        result = chart.ordinate_values_at_abscissa_value(0.5)
         # assert
         self.assertEqual(result, [("Vout", "V", [20.0])])
 
-    def test_sample_at_multiple_series(self):
+    def test_ordinate_values_at_abscissa_value_multiple_series(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 1.0, 5), "s")
@@ -477,7 +381,7 @@ class TestChart(TestCase):
         chart._series["Vout"] = (vout, {vout: (mock_axis, {0: MagicMock()}, 10.0, 50.0, "#f77f00")})
         chart._series["Iout"] = (iout, {iout: (mock_axis, {0: MagicMock()}, 1.0, 5.0, "#00b4d8")})
         # act — x_ratio=0.0 → index 0
-        result = chart.sample_at(0.0)
+        result = chart.ordinate_values_at_abscissa_value(0.0)
         # assert — two entries returned, one per series
         self.assertEqual(len(result), 2)
         names = {r[0] for r in result}
@@ -568,7 +472,7 @@ class TestChart(TestCase):
         self.assertTrue(removed)
         self.assertIsNone(chart._right_y_axis_2)
 
-    def test_sample_at_prefers_rendered_decimated_points_over_raw_samples(self):
+    def test_ordinate_values_at_abscissa_value_prefers_rendered_decimated_points_over_raw_samples(self):
         # arrange
         component = MagicMock()
         abscissa = Expression("Time", np.linspace(0.0, 10.0, 11), "s")
@@ -580,7 +484,7 @@ class TestChart(TestCase):
         # rendered decimated points shown on chart near the same x do not include the raw spike
         chart._sample_cache[vout] = {0: (np.array([0.0, 5.0, 10.0]), np.array([0.0, 3.9, 0.0]))}
         # act
-        result = chart.sample_at(0.5)
+        result = chart.ordinate_values_at_abscissa_value(0.5)
         # assert
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0][0], "Vout")

--- a/tests/chart_test.py
+++ b/tests/chart_test.py
@@ -10,7 +10,7 @@ sys.modules.setdefault("PySide6.QtCore", MagicMock())
 sys.modules.setdefault("PySide6.QtGraphs", MagicMock())
 sys.modules.setdefault("PySide6.QtQuick", MagicMock())
 
-from viewer.chart import Chart  # noqa: E402
+from viewer.chart import Chart, _binary_search, _find_abscissa_index_for_value  # noqa: E402
 from viewer.expression import Expression  # noqa: E402
 from viewer.qraw_file import StepInformation  # noqa: E402
 
@@ -28,7 +28,101 @@ def _make_step_information(num_steps: int, abscissa_length: int, ascending: bool
     return StepInformation(keys, values, abscissa_indices, abscissa_value_ranges)
 
 
+def _make_component_with_y_axis() -> MagicMock:
+    component = MagicMock()
+
+    def createYAxis(alignment, unit):
+        axis = MagicMock()
+        axis.property = MagicMock(return_value=unit)
+        return axis
+
+    component.createYAxis = MagicMock(side_effect=createYAxis)
+    component.removeAllSeries = MagicMock()
+    component.updateGraphsView = MagicMock()
+    component.resizeAbscissa = MagicMock()
+    return component
+
+
 class TestChart(TestCase):
+
+    def test_binary_search_descending_and_out_of_bounds(self):
+        # arrange
+        data = np.array([10, 8, 6, 4, 2, 0])
+        # act & assert — value in range
+        self.assertEqual(_binary_search(data, 6, ascending=False, side=1), 2)
+        # act & assert — value below range
+        self.assertEqual(_binary_search(data, -5, ascending=False, side=1), 6)
+        # act & assert — value above range
+        self.assertEqual(_binary_search(data, 15, ascending=False, side=1), 0)
+        # act & assert — _find_abscissa_index_for_value clamps to valid range
+        self.assertEqual(_find_abscissa_index_for_value(data, -5, ascending=False), 5)
+        self.assertEqual(_find_abscissa_index_for_value(data, 15, ascending=False), 0)
+
+    def test_plot_series_axis_creation_failure_logs_warning(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.linspace(0.0, 1.0, 10), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
+        vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
+        # patch _get_y_axis to return None to simulate axis creation failure
+        chart._get_y_axis = MagicMock(return_value=None)
+        with self.assertLogs("viewer.chart", level="WARNING") as cm:
+            chart.plot_series({vout})
+        # assert — warning about axis creation failure
+        self.assertTrue(any("maximum number of Y axes reached" in msg for msg in cm.output[0:2]))
+
+    def test_plot_series_skips_all_nonfinite(self):
+        # arrange
+        component = _make_component_with_y_axis()
+        abscissa = Expression("Time", np.linspace(0.0, 1.0, 10), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
+        vout = Expression("Vout", np.full(10, np.inf), "V")
+        # patch decimate_xy to return all non-finite values
+        with patch("viewer.chart.decimate_xy", return_value=(np.arange(10), np.full(10, np.inf))):
+            chart.plot_series({vout})
+        # assert — no rendered step data is stored for the expression
+        self.assertEqual(len(chart._series["Vout"][1]), 1)
+        ordinate_series = next(iter(chart._series["Vout"][1].values()))
+        self.assertEqual(ordinate_series[1], {})
+
+    def test_color_cycling_wraps_palette(self):
+        # arrange
+        component = _make_component_with_y_axis()
+        abscissa = Expression("Time", np.linspace(0.0, 1.0, 10), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
+        # patch decimate_xy to always return valid data
+        with patch("viewer.chart.decimate_xy", return_value=(np.arange(10), np.arange(10))):
+            for i in range(20):
+                expr = Expression(f"V{i}", np.arange(10), "V")
+                chart.plot_series({expr})
+        # assert — color index wraps, palette length is 14
+        self.assertLessEqual(chart._next_color_index, 20)
+
+    def test_find_abscissa_indexes_outside_window_and_descending(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.array([10, 8, 6, 4, 2, 0]), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 6, ascending=False), 500)
+        # act — window outside data range (should return empty slice)
+        result = chart._find_abscissa_indexes(abscissa.data, 20, 30)
+        # assert
+        self.assertEqual(result, slice(0, 0))
+
+    def test_redraw_all_series_skips_empty_decimation(self):
+        # arrange
+        component = MagicMock()
+        abscissa = Expression("Time", np.linspace(0.0, 1.0, 10), "s")
+        chart = Chart(component, "AC", MagicMock(), abscissa, _make_step_information(1, 10), 500)
+        vout = Expression("Vout", np.linspace(0.0, 5.0, 10), "V")
+        y_axis = MagicMock()
+        # inject a series with a real QLineSeries
+        chart._series = {"Vout": (vout, {vout: (y_axis, {0: MagicMock()}, 0.0, 5.0, "#f77f00")})}
+        chart._zoom_window = (0.0, None, 1.0, None)
+        # patch decimate_xy to return empty arrays
+        with patch("viewer.chart.decimate_xy", return_value=(np.array([]), np.array([]))):
+            chart._redraw_all_series()
+        # assert — no exception, series remains
+        self.assertIn("Vout", chart._series)
 
     def test_init_zoom_window(self):
         # arrange

--- a/tests/fft_dialog_test.py
+++ b/tests/fft_dialog_test.py
@@ -174,44 +174,6 @@ class TestFftDialogOnDialogAccepted(TestCase):
         self.assertEqual(dialog._result_from_index, 0.0)
         self.assertEqual(dialog._result_to_index, 1.0)
 
-    def test_range_mode_zoom_uses_stored_zoom_window(self):
-        # arrange — zoom window [0.3, 0.8]
-        dialog, _e1, _e2 = _make_dialog(np.linspace(0.0, 1.0, 11), zoom_from=0.3, zoom_to=0.8)
-        # act
-        dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "zoom", 0.0, 1.0, False)
-        # assert
-        self.assertEqual(dialog._result_from_index, 0.3)
-        self.assertEqual(dialog._result_to_index, 0.8)
-
-    def test_range_mode_custom_uses_clamped_values(self):
-        # arrange — 11-point abscissa 0…1 s
-        abscissa = np.linspace(0.0, 1.0, 11)
-        dialog, _e1, _e2 = _make_dialog(abscissa)
-        # act — request range 0.2 s … 0.8 s (avoid 0.6 which has floating-point representability issues)
-        dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "custom", 0.2, 0.8, False)
-        # assert — custom values are stored directly after domain clamping
-        self.assertEqual(dialog._result_from_index, 0.2)
-        self.assertEqual(dialog._result_to_index, 0.8)
-
-    def test_range_mode_custom_clamps_above_total(self):
-        # arrange
-        abscissa = np.linspace(0.0, 1.0, 11)
-        dialog, _e1, _e2 = _make_dialog(abscissa)
-        # act — to_time beyond the end of the array
-        dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "custom", 0.5, 999.0, False)
-        # assert — upper bound clamped to the last abscissa value
-        self.assertEqual(dialog._result_to_index, 1.0)
-
-    def test_range_mode_custom_preserves_single_value_window(self):
-        # arrange — exact single-value custom range
-        abscissa = np.linspace(0.0, 1.0, 11)
-        dialog, _e1, _e2 = _make_dialog(abscissa)
-        # act
-        dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "custom", 0.5, 0.5, False)
-        # assert
-        self.assertEqual(dialog._result_from_index, 0.5)
-        self.assertEqual(dialog._result_to_index, 0.5)
-
     def test_range_mode_unknown_falls_back_to_full(self):
         # arrange
         dialog, _e1, _e2 = _make_dialog(np.linspace(0.0, 1.0, 11))

--- a/tests/fft_dialog_test.py
+++ b/tests/fft_dialog_test.py
@@ -13,11 +13,23 @@ sys.modules.setdefault("PySide6.QtWidgets", MagicMock())
 # Slot must act as a pass-through decorator so @Slot(...) does not replace the method with a mock
 sys.modules["PySide6.QtCore"].Slot = lambda *a, **kw: (lambda f: f)
 # QDialog must be a concrete class so that FftDialog can genuinely inherit from it
-sys.modules["PySide6.QtWidgets"].QDialog = type("QDialog", (), {"accept": lambda self: None, "reject": lambda self: None})
+sys.modules["PySide6.QtWidgets"].QDialog = type(
+    "QDialog",
+    (),
+    {
+        "__init__": lambda self, parent=None: None,
+        "accept": lambda self: None,
+        "reject": lambda self: None,
+        "setWindowTitle": lambda self, title: None,
+        "setWindowModality": lambda self, modality: None,
+        "resize": lambda self, width, height: None,
+        "setMinimumHeight": lambda self, height: None,
+    },
+)
 
 from viewer.expression import Expression  # noqa: E402
 from viewer.fft import FftOutput, WindowFunction, ZeroPadding  # noqa: E402
-from viewer.fft_dialog import FftDialog  # noqa: E402
+from viewer.fft_dialog import FftDialog, QQuickView  # noqa: E402
 
 
 def _make_dialog(abscissa_values=None, zoom_from=0, zoom_to=10):
@@ -200,7 +212,52 @@ class TestFftDialogOnDialogAccepted(TestCase):
         self.assertFalse(dialog._result_keep_dc)
 
 
-class TestFftDialogResultProperties(TestCase):
+class TestFftDialogInitAndQml(TestCase):
+
+    def test_constructor_sets_fields_and_ctx_properties(self):
+        # arrange
+        parent = MagicMock()
+        expressions = [Expression("A", np.arange(5), "V"), Expression("B", np.arange(5), "A")]
+        min_val = 0.0
+        max_val = 10.0
+        min_zoom = 2.0
+        max_zoom = 8.0
+        # act
+        dialog = FftDialog(parent, expressions, min_val, max_val, min_zoom, max_zoom)
+        # assert
+        self.assertEqual(dialog._expressions, expressions)
+        self.assertEqual(dialog._selected_expressions, set(expressions))
+        self.assertEqual(dialog._result_from_index, min_val)
+        self.assertEqual(dialog._result_to_index, max_val)
+        self.assertEqual(dialog._result_window, WindowFunction.HANNING)
+        self.assertEqual(dialog._result_zero_pad, ZeroPadding.NONE)
+        self.assertFalse(dialog._result_normalize)
+        self.assertFalse(dialog._result_keep_dc)
+        self.assertEqual(dialog._result_output, FftOutput.MAGNITUDE)
+        self.assertIn("windowFunctions", dialog._ctx_properties)
+        self.assertIn("outputTypes", dialog._ctx_properties)
+        self.assertIn("zeroPaddingOptions", dialog._ctx_properties)
+        self.assertEqual(dialog._ctx_properties["abscissaMin"], min_val)
+        self.assertEqual(dialog._ctx_properties["abscissaMax"], max_val)
+        self.assertEqual(dialog._ctx_properties["zoomFromTime"], min_zoom)
+        self.assertEqual(dialog._ctx_properties["zoomToTime"], max_zoom)
+
+    def test_on_qml_ready_injects_properties_and_connects_signals(self):
+        # arrange
+        dialog, _e1, _e2 = _make_dialog()
+        mock_root = MagicMock()
+        dialog._qml_view = MagicMock()
+        dialog._qml_view.rootObject.return_value = mock_root
+        dialog._ctx_properties = {"foo": 123, "bar": 456}
+        # act
+        dialog._on_qml_ready(QQuickView.Status.Ready)
+        # assert
+        mock_root.setProperty.assert_any_call("foo", 123)
+        mock_root.setProperty.assert_any_call("bar", 456)
+        mock_root.initializeExpressions.assert_called()
+        mock_root.selectionChanged.connect.assert_called_with(dialog._on_expression_selection_changed)
+        mock_root.dialogAccepted.connect.assert_called_with(dialog._on_dialog_accepted)
+        mock_root.dialogRejected.connect.assert_called_with(dialog.reject)
 
     def test_result_expressions_property_default_is_empty_list(self):
         # arrange

--- a/tests/fft_dialog_test.py
+++ b/tests/fft_dialog_test.py
@@ -27,15 +27,15 @@ def _make_dialog(abscissa_values=None, zoom_from=0, zoom_to=10):
     abscissa = Expression("Time", abscissa_values, "s")
     e1 = Expression("V(R1)", np.ones(len(abscissa_values)), "V")
     e2 = Expression("I(L1)", np.ones(len(abscissa_values)) * 2.0, "A")
-    dialog = FftDialog.__new__(FftDialog)
+    dialog = object.__new__(FftDialog)
     dialog._expressions = [e1, e2]
     dialog._abscissa = abscissa
     dialog._zoom_from_index = zoom_from
     dialog._zoom_to_index = zoom_to
     dialog._selected_expressions = {e1, e2}
     dialog._result_expressions = []
-    dialog._result_from_index = 0
-    dialog._result_to_index = len(abscissa_values)
+    dialog._result_from_index = float(abscissa_values[0])
+    dialog._result_to_index = float(abscissa_values[-1])
     dialog._result_window = WindowFunction.RECTANGULAR
     dialog._result_zero_pad = ZeroPadding.NONE
     dialog._result_normalize = False
@@ -171,30 +171,27 @@ class TestFftDialogOnDialogAccepted(TestCase):
         # act
         dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "full", 0.0, 1.0, False)
         # assert
-        self.assertEqual(dialog._result_from_index, 0)
-        self.assertEqual(dialog._result_to_index, 11)
+        self.assertEqual(dialog._result_from_index, 0.0)
+        self.assertEqual(dialog._result_to_index, 1.0)
 
     def test_range_mode_zoom_uses_stored_zoom_window(self):
-        # arrange — zoom window [3, 8)
-        dialog, _e1, _e2 = _make_dialog(np.linspace(0.0, 1.0, 11), zoom_from=3, zoom_to=8)
+        # arrange — zoom window [0.3, 0.8]
+        dialog, _e1, _e2 = _make_dialog(np.linspace(0.0, 1.0, 11), zoom_from=0.3, zoom_to=0.8)
         # act
         dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "zoom", 0.0, 1.0, False)
         # assert
-        self.assertEqual(dialog._result_from_index, 3)
-        self.assertEqual(dialog._result_to_index, 8)
+        self.assertEqual(dialog._result_from_index, 0.3)
+        self.assertEqual(dialog._result_to_index, 0.8)
 
-    def test_range_mode_custom_maps_time_to_indices(self):
+    def test_range_mode_custom_uses_clamped_values(self):
         # arrange — 11-point abscissa 0…1 s
         abscissa = np.linspace(0.0, 1.0, 11)
         dialog, _e1, _e2 = _make_dialog(abscissa)
         # act — request range 0.2 s … 0.8 s (avoid 0.6 which has floating-point representability issues)
         dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "custom", 0.2, 0.8, False)
-        # assert — from_index=2 for 0.2; to_index verified against actual searchsorted output
-        self.assertEqual(dialog._result_from_index, 2)
-        # searchsorted(arr, 0.8, side='right') where arr[8]=0.8 → position 9
-        import numpy as _np
-        expected_to = int(_np.searchsorted(abscissa, 0.8, side="right"))
-        self.assertEqual(dialog._result_to_index, expected_to)
+        # assert — custom values are stored directly after domain clamping
+        self.assertEqual(dialog._result_from_index, 0.2)
+        self.assertEqual(dialog._result_to_index, 0.8)
 
     def test_range_mode_custom_clamps_above_total(self):
         # arrange
@@ -202,17 +199,18 @@ class TestFftDialogOnDialogAccepted(TestCase):
         dialog, _e1, _e2 = _make_dialog(abscissa)
         # act — to_time beyond the end of the array
         dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "custom", 0.5, 999.0, False)
-        # assert — to_index clamped to total (11)
-        self.assertEqual(dialog._result_to_index, 11)
+        # assert — upper bound clamped to the last abscissa value
+        self.assertEqual(dialog._result_to_index, 1.0)
 
-    def test_range_mode_custom_ensures_minimum_two_samples(self):
-        # arrange — very narrow custom range that resolves to the same index
+    def test_range_mode_custom_preserves_single_value_window(self):
+        # arrange — exact single-value custom range
         abscissa = np.linspace(0.0, 1.0, 11)
         dialog, _e1, _e2 = _make_dialog(abscissa)
-        # act — from_time and to_time both map to index 5
+        # act
         dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "custom", 0.5, 0.5, False)
-        # assert — at least 2 samples guaranteed
-        self.assertGreaterEqual(dialog._result_to_index - dialog._result_from_index, 2)
+        # assert
+        self.assertEqual(dialog._result_from_index, 0.5)
+        self.assertEqual(dialog._result_to_index, 0.5)
 
     def test_range_mode_unknown_falls_back_to_full(self):
         # arrange
@@ -220,8 +218,8 @@ class TestFftDialogOnDialogAccepted(TestCase):
         # act — unrecognised range_mode triggers full-range fallback
         dialog._on_dialog_accepted("Rectangular", "None", "Magnitude", False, "unknown_mode", 0.0, 1.0, False)
         # assert
-        self.assertEqual(dialog._result_from_index, 0)
-        self.assertEqual(dialog._result_to_index, 11)
+        self.assertEqual(dialog._result_from_index, 0.0)
+        self.assertEqual(dialog._result_to_index, 1.0)
 
     def test_keep_dc_flag_true(self):
         # arrange
@@ -258,16 +256,16 @@ class TestFftDialogResultProperties(TestCase):
     def test_result_from_index_property(self):
         # arrange
         dialog, _e1, _e2 = _make_dialog()
-        dialog._result_from_index = 4
+        dialog._result_from_index = 0.4
         # act / assert
-        self.assertEqual(dialog.result_from_index, 4)
+        self.assertEqual(dialog.result_from_index, 0.4)
 
     def test_result_to_index_property(self):
         # arrange
         dialog, _e1, _e2 = _make_dialog()
-        dialog._result_to_index = 7
+        dialog._result_to_index = 0.7
         # act / assert
-        self.assertEqual(dialog.result_to_index, 7)
+        self.assertEqual(dialog.result_to_index, 0.7)
 
     def test_result_window_property(self):
         # arrange

--- a/tests/main_entry_test.py
+++ b/tests/main_entry_test.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+# mock PySide6 submodules before importing viewer.__main__, which requires Qt at import time
+sys.modules.setdefault("PySide6", MagicMock())
+sys.modules.setdefault("PySide6.QtCore", MagicMock())
+sys.modules.setdefault("PySide6.QtWidgets", MagicMock())
+
+
+class TestMainEntry(TestCase):
+
+    def test_main_gui_uses_shared_open_path(self):
+        # arrange
+        main_entry = importlib.import_module("viewer.__main__")
+        app = MagicMock()
+        app.exec.return_value = 0
+        icon = MagicMock()
+        icon.isNull.return_value = True
+        window = MagicMock()
+        # act
+        with patch.object(sys, "argv", ["viewer", "test.qraw"]), \
+             patch.object(main_entry, "QApplication", return_value=app), \
+             patch.object(main_entry, "load_app_icon", return_value=icon), \
+             patch.object(main_entry, "open_qraw_as_window", return_value=window) as mock_open:
+            with self.assertRaises(SystemExit) as exit_context:
+                main_entry.main()
+        # assert
+        self.assertEqual(exit_context.exception.code, 0)
+        mock_open.assert_called_once()
+        window.show.assert_called_once_with()
+        app.exec.assert_called_once_with()
+
+    def test_main_gui_exits_with_error_when_open_fails(self):
+        # arrange
+        main_entry = importlib.import_module("viewer.__main__")
+        app = MagicMock()
+        icon = MagicMock()
+        icon.isNull.return_value = True
+        # act
+        with patch.object(sys, "argv", ["viewer", "test.qraw"]), \
+             patch.object(main_entry, "QApplication", return_value=app), \
+             patch.object(main_entry, "load_app_icon", return_value=icon), \
+             patch.object(main_entry, "open_qraw_as_window", return_value=None) as mock_open:
+            with self.assertRaises(SystemExit) as exit_context:
+                main_entry.main()
+        # assert
+        self.assertEqual(exit_context.exception.code, 1)
+        mock_open.assert_called_once()
+        app.exec.assert_not_called()

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -19,7 +19,7 @@ sys.modules["PySide6.QtCore"].Slot = lambda *a, **kw: (lambda f: f)
 sys.modules["PySide6.QtWidgets"].QMainWindow = type("QMainWindow", (), {})
 
 from viewer.expression import Expression  # noqa: E402
-from viewer.main_window import MainWindow, _build_step_combinations, _compute_decimate_target, _FALLBACK_DECIMATE_TARGET, _format_value, _format_values  # noqa: E402
+from viewer.main_window import MainWindow, _compute_decimate_target, _FALLBACK_DECIMATE_TARGET, _format_value, _format_values  # noqa: E402
 
 
 class TestMainWindow(TestCase):
@@ -189,40 +189,6 @@ class TestFormatValues(TestCase):
         result = _format_values("I(L1)", [1e-3, 2e-3], "A")
         # assert — SI prefix applied per-value
         self.assertEqual(result, "I(L1) = [1.00 mA, 2.00 mA]")
-
-
-class TestBuildStepCombinations(TestCase):
-
-    def test_returns_empty_when_single_step(self):
-        # arrange
-        expressions = [Expression("Rload", np.array([1.0]), "", variable_type="parameter")]
-        # act
-        parameter_names, combinations = _build_step_combinations(expressions, 1, 1)
-        # assert
-        self.assertEqual(parameter_names, [])
-        self.assertEqual(combinations, [])
-
-    def test_uses_single_step_abscissa_length_for_parameter_rows(self):
-        # arrange
-        expressions = [
-            Expression("Rload", np.array([10.0, 10.0, 10.0, 10.0, 22.0, 22.0, 22.0, 22.0, 47.0, 47.0, 47.0, 47.0]), "", variable_type="parameter"),
-            Expression("V(out)", np.array([1.0] * 12), "V", variable_type="voltage")
-        ]
-        # act
-        parameter_names, combinations = _build_step_combinations(expressions, 3, 4)
-        # assert
-        self.assertEqual(parameter_names, ["Rload"])
-        self.assertEqual([combination.step_index for combination in combinations], [0, 1, 2])
-        self.assertEqual([combination.values for combination in combinations], [["10"], ["22"], ["47"]])
-
-    def test_returns_empty_when_no_parameter_variables_exist(self):
-        # arrange
-        expressions = [Expression("V(out)", np.array([1.0, 2.0]), "V", variable_type="voltage")]
-        # act
-        parameter_names, combinations = _build_step_combinations(expressions, 3, 2)
-        # assert
-        self.assertEqual(parameter_names, [])
-        self.assertEqual(combinations, [])
 
 
 class TestMainWindowSlots(TestCase):

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -20,120 +20,34 @@ sys.modules["PySide6.QtWidgets"].QMainWindow = type("QMainWindow", (), {})
 
 from viewer.expression import Expression  # noqa: E402
 from viewer.main_window import MainWindow, _compute_decimate_target, _FALLBACK_DECIMATE_TARGET, _format_value, _format_values  # noqa: E402
+from viewer.qraw_file import StepInformation  # noqa: E402
 
 
 class TestMainWindow(TestCase):
 
-    def test_zoom_in_reduces_window(self):
+    def test_zoom_region_selected_updates_target_chart_with_full_window(self):
         # arrange
         win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 0
-        win._abscissa_to_index = 20
+        chart0 = MagicMock()
+        chart1 = MagicMock()
+        win._charts = [chart0, chart1]
         # act
-        win._on_horizontal_zoom(0, 0.3, 0.7, 0.5)
-        # assert
-        new_width = win._abscissa_to_index - win._abscissa_from_index
-        self.assertLess(new_width, 20)
-        self.assertGreaterEqual(win._abscissa_from_index, 0)
-        self.assertLessEqual(win._abscissa_to_index, 20)
+        win._on_zoom_region_selected(0, 0.25, 0.15, 0.75, 0.85)
+        # assert — target chart gets both horizontal and vertical zoom
+        chart0.update_zoom_window.assert_called_once_with(0.25, 0.75, 0.15, 0.85)
+        chart1.update_zoom_window.assert_called_once_with(0.25, 0.75, None, None)
 
-    def test_zoom_out_moves_window_outward(self):
+    def test_zoom_region_selected_normalizes_inverted_ratios(self):
         # arrange
         win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 5
-        win._abscissa_to_index = 15
-        old_width = win._abscissa_to_index - win._abscissa_from_index
+        chart0 = MagicMock()
+        chart1 = MagicMock()
+        win._charts = [chart0, chart1]
         # act
-        win._on_horizontal_zoom(0, 0.25, 0.75, 2.0)
-        # assert
-        new_width = win._abscissa_to_index - win._abscissa_from_index
-        self.assertNotEqual(new_width, old_width)
-        self.assertGreaterEqual(new_width, 2)
-        self.assertLessEqual(win._abscissa_to_index, 20)
-
-    def test_zoom_out_at_boundary_saturates(self):
-        # arrange
-        win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 0
-        win._abscissa_to_index = 20
-        # act — repeated zoom-out gestures must never push indices outside data bounds
-        for _ in range(5):
-            win._on_horizontal_zoom(0, 0.0, 1.0, 2.0)
-        # assert
-        self.assertEqual(win._abscissa_from_index, 0)
-        self.assertEqual(win._abscissa_to_index, 20)
-
-    def test_minimum_window_enforced(self):
-        # arrange
-        win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 0
-        win._abscissa_to_index = 20
-        # act — repeated zoom-in must never produce a window smaller than two points
-        for _ in range(50):
-            win._on_horizontal_zoom(0, 0.4, 0.6, 0.5)
-        # assert
-        width = win._abscissa_to_index - win._abscissa_from_index
-        self.assertGreaterEqual(width, 2)
-
-    def test_pan_moves_window_right(self):
-        # arrange
-        win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 5
-        win._abscissa_to_index = 15
-        # act — zoom_factor=1.0 signals a pure pan; positive x_left_ratio shifts right
-        win._on_horizontal_zoom(0, 0.2, 1.2, 1.0)
-        # assert
-        self.assertGreater(win._abscissa_from_index, 5)
-        self.assertGreater(win._abscissa_to_index, 15)
-
-    def test_pan_moves_window_left(self):
-        # arrange
-        win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 5
-        win._abscissa_to_index = 15
-        # act — zoom_factor=1.0 signals a pure pan; negative x_left_ratio shifts left
-        win._on_horizontal_zoom(0, -0.2, 0.8, 1.0)
-        # assert
-        self.assertLess(win._abscissa_from_index, 5)
-        self.assertLess(win._abscissa_to_index, 15)
-
-    def test_pan_clamps_at_left_boundary(self):
-        # arrange
-        win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 0
-        win._abscissa_to_index = 10
-        # act — pan left when already at the left boundary must not go below zero
-        win._on_horizontal_zoom(0, -0.2, 0.8, 1.0)
-        # assert
-        self.assertEqual(win._abscissa_from_index, 0)
-        self.assertEqual(win._abscissa_to_index, 10)
-
-    def test_pan_clamps_at_right_boundary(self):
-        # arrange
-        win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(20)))
-        win._charts = []
-        win._abscissa_from_index = 10
-        win._abscissa_to_index = 20
-        # act — pan right when already at the right boundary must not exceed total length
-        win._on_horizontal_zoom(0, 0.2, 1.2, 1.0)
-        # assert
-        self.assertEqual(win._abscissa_from_index, 10)
-        self.assertEqual(win._abscissa_to_index, 20)
+        win._on_zoom_region_selected(0, 0.8, 0.9, 0.2, 0.1)
+        # assert — inverted ranges are normalized before passing to charts
+        chart0.update_zoom_window.assert_called_once_with(0.2, 0.8, 0.1, 0.9)
+        chart1.update_zoom_window.assert_called_once_with(0.2, 0.8, None, None)
 
 
 class TestFormatValue(TestCase):
@@ -196,35 +110,18 @@ class TestMainWindowSlots(TestCase):
     def _make_win(self, total=20):
         # build a bare MainWindow bypassing __init__
         win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=list(range(total)), values=list(range(total)))
+        win._abscissa = MagicMock(data=list(range(total)), values=list(range(total)), unit="s", name="time")
         win._default_chart_type = "AC"
         win._charts = []
         win._abscissa_from_index = 0
         win._abscissa_to_index = total
+        win._step_information = StepInformation([], [()], [slice(0, total)], [(0.0, float(total - 1))])
+        win._decimate_target = _FALLBACK_DECIMATE_TARGET
+        win._abscissa_scale = MagicMock(value="lin")
+        win._qraw_path = MagicMock()
+        win._qraw_file = MagicMock()
+        win._initial_selected_steps = None
         return win
-
-    def test_vertical_zoom_delegates_to_chart(self):
-        # arrange
-        win = self._make_win()
-        chart = MagicMock()
-        win._charts = [chart]
-        # act
-        win._on_vertical_zoom(0, 0.2, 0.8)
-        # assert — per-chart vertical zoom only; horizontal indices passed as -1
-        chart.update_zoom_window.assert_called_once_with(-1, -1, 0.2, 0.8)
-
-    def test_menu_zoom_to_fit_resets_to_full_range(self):
-        # arrange
-        win = self._make_win(total=100)
-        win._abscissa_from_index = 20
-        win._abscissa_to_index = 80
-        chart = MagicMock()
-        win._charts = [chart]
-        # act
-        win._on_menu_zoom_to_fit(0)
-        # assert — from/to indices reset to full range
-        self.assertEqual(win._abscissa_from_index, 0)
-        self.assertEqual(win._abscissa_to_index, 100)
 
     def test_menu_zoom_to_fit_resets_target_chart_zoom(self):
         # arrange
@@ -234,9 +131,9 @@ class TestMainWindowSlots(TestCase):
         win._charts = [chart0, chart1]
         # act
         win._on_menu_zoom_to_fit(0)
-        # assert — chart at target index gets reset_zoom_window; others get update_zoom_window
-        chart0.reset_zoom_window.assert_called_once_with(0, 100, 0.0, 1.0)
-        chart1.update_zoom_window.assert_called_once_with(0, 100, None, None)
+        # assert — chart at target index resets both dimensions and other charts reset horizontal only
+        chart0.reset_zoom_window.assert_called_once_with(True, True)
+        chart1.reset_zoom_window.assert_called_once_with(True, False)
 
     def test_menu_autorange_calls_reset_on_chart(self):
         # arrange
@@ -245,23 +142,10 @@ class TestMainWindowSlots(TestCase):
         win._charts = [chart]
         # act
         win._on_menu_autorange(0)
-        # assert — vertical zoom reset; horizontal left unchanged (pass -1)
-        chart.reset_zoom_window.assert_called_once_with(-1, -1, 0.0, 1.0)
+        # assert — vertical zoom reset only
+        chart.reset_zoom_window.assert_called_once_with(False, True)
 
-    def test_menu_zoom_abscissa_extent_resets_indices(self):
-        # arrange
-        win = self._make_win(total=50)
-        win._abscissa_from_index = 10
-        win._abscissa_to_index = 40
-        chart = MagicMock()
-        win._charts = [chart]
-        # act
-        win._on_menu_zoom_abscissa_extent(0)
-        # assert — indices reset to full abscissa extent
-        self.assertEqual(win._abscissa_from_index, 0)
-        self.assertEqual(win._abscissa_to_index, 50)
-
-    def test_menu_zoom_abscissa_extent_calls_reset_on_all_charts(self):
+    def test_menu_zoom_abscissa_extent_resets_horizontal_zoom_on_all_charts(self):
         # arrange
         win = self._make_win(total=50)
         c0 = MagicMock()
@@ -269,9 +153,9 @@ class TestMainWindowSlots(TestCase):
         win._charts = [c0, c1]
         # act
         win._on_menu_zoom_abscissa_extent(0)
-        # assert
-        c0.reset_zoom_window.assert_called_once_with(0, 50, None, None)
-        c1.reset_zoom_window.assert_called_once_with(0, 50, None, None)
+        # assert — all charts reset horizontal zoom only
+        c0.reset_zoom_window.assert_called_once_with(True, False)
+        c1.reset_zoom_window.assert_called_once_with(True, False)
 
     def test_menu_delete_all_plots_clears_chart(self):
         # arrange
@@ -319,9 +203,9 @@ class TestMainWindowSlots(TestCase):
         win._qraw_path = MagicMock()
         created_window = MagicMock()
         # act
-        with patch("viewer.main_window.MainWindow", return_value=created_window) as mock_main_window, \
-             patch("viewer.main_window._register_child_window") as mock_register:
-            win._on_menu_new_window()
+        with patch("viewer.main_window.MainWindow", return_value=created_window) as mock_main_window:
+            with patch("viewer.main_window._register_child_window") as mock_register:
+                win._on_menu_new_window()
         # assert
         mock_main_window.assert_called_once_with(win._qraw_file, source_qraw_path=win._qraw_path, start_empty=True)
         mock_register.assert_called_once_with(created_window)
@@ -332,10 +216,10 @@ class TestMainWindowSlots(TestCase):
         win = self._make_win()
         created_window = MagicMock()
         # act
-        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/example.qraw", "QRAW Files (*.qraw)")), \
-             patch("viewer.main_window.open_qraw_as_window", return_value=created_window) as mock_open, \
-             patch("viewer.main_window._register_child_window") as mock_register:
-            win._on_menu_open_file()
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/example.qraw", "QRAW Files (*.qraw)")):
+            with patch("viewer.main_window.open_qraw_as_window", return_value=created_window) as mock_open:
+                with patch("viewer.main_window._register_child_window") as mock_register:
+                    win._on_menu_open_file()
         # assert
         mock_open.assert_called_once()
         mock_register.assert_called_once_with(created_window)
@@ -345,10 +229,10 @@ class TestMainWindowSlots(TestCase):
         # arrange
         win = self._make_win()
         # act
-        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("", "QRAW Files (*.qraw)")), \
-             patch("viewer.main_window.open_qraw_as_window") as mock_open, \
-             patch("viewer.main_window._register_child_window") as mock_register:
-            win._on_menu_open_file()
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("", "QRAW Files (*.qraw)")):
+            with patch("viewer.main_window.open_qraw_as_window") as mock_open:
+                with patch("viewer.main_window._register_child_window") as mock_register:
+                    win._on_menu_open_file()
         # assert
         mock_open.assert_not_called()
         mock_register.assert_not_called()
@@ -357,10 +241,10 @@ class TestMainWindowSlots(TestCase):
         # arrange
         win = self._make_win()
         # act
-        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/bad.qraw", "QRAW Files (*.qraw)")), \
-             patch("viewer.main_window.open_qraw_as_window", return_value=None) as mock_open, \
-             patch("viewer.main_window._register_child_window") as mock_register:
-            win._on_menu_open_file()
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/bad.qraw", "QRAW Files (*.qraw)")):
+            with patch("viewer.main_window.open_qraw_as_window", return_value=None) as mock_open:
+                with patch("viewer.main_window._register_child_window") as mock_register:
+                    win._on_menu_open_file()
         # assert
         mock_open.assert_called_once()
         mock_register.assert_not_called()
@@ -369,10 +253,10 @@ class TestMainWindowSlots(TestCase):
         # arrange
         win = self._make_win()
         # act
-        with patch("viewer.main_window._OPEN_FILE_DIALOG_ACTIVE", True), \
-             patch("viewer.main_window.QFileDialog.getOpenFileName") as mock_dialog, \
-             patch("viewer.main_window.open_qraw_as_window") as mock_open:
-            win._on_menu_open_file()
+        with patch("viewer.main_window._OPEN_FILE_DIALOG_ACTIVE", True):
+            with patch("viewer.main_window.QFileDialog.getOpenFileName") as mock_dialog:
+                with patch("viewer.main_window.open_qraw_as_window") as mock_open:
+                    win._on_menu_open_file()
         # assert
         mock_dialog.assert_not_called()
         mock_open.assert_not_called()
@@ -380,39 +264,42 @@ class TestMainWindowSlots(TestCase):
     def test_on_qml_ready_sets_step_tool_enabled_for_stepped_files(self):
         # arrange
         win = self._make_win()
-        win._steps = 6
+        win._step_information = StepInformation([], [()] * 6, [slice(0, 1)] * 6, [(0.0, 1.0)] * 6)
         win._abscissa = MagicMock(unit="s", data=list(range(20)), values=list(range(20)))
         win._qml_view = MagicMock()
         root = MagicMock()
         win._qml_view.rootObject.return_value = root
         # act
-        win._on_qml_ready(sys.modules["PySide6.QtQuick"].QQuickView.Status.Ready)
+        with patch("viewer.main_window.QQuickView.Status.Ready", "READY"):
+            win._on_qml_ready("READY")
         # assert
         root.setProperty.assert_any_call("stepToolEnabled", True)
 
     def test_on_qml_ready_sets_step_tool_disabled_for_single_step_files(self):
         # arrange
         win = self._make_win()
-        win._steps = 1
+        win._step_information = StepInformation([], [()], [slice(0, 1)], [(0.0, 1.0)])
         win._abscissa = MagicMock(unit="s", data=list(range(20)), values=list(range(20)))
         win._qml_view = MagicMock()
         root = MagicMock()
         win._qml_view.rootObject.return_value = root
         # act
-        win._on_qml_ready(sys.modules["PySide6.QtQuick"].QQuickView.Status.Ready)
+        with patch("viewer.main_window.QQuickView.Status.Ready", "READY"):
+            win._on_qml_ready("READY")
         # assert
         root.setProperty.assert_any_call("stepToolEnabled", False)
 
     def test_on_qml_ready_converts_numpy_step_bool_to_python_bool(self):
         # arrange
         win = self._make_win()
-        win._steps = np.int64(6)
+        win._step_information = StepInformation([], [()] * 6, [slice(0, 1)] * 6, [(0.0, 1.0)] * 6)
         win._abscissa = MagicMock(unit="s", data=list(range(20)), values=list(range(20)))
         win._qml_view = MagicMock()
         root = MagicMock()
         win._qml_view.rootObject.return_value = root
         # act
-        win._on_qml_ready(sys.modules["PySide6.QtQuick"].QQuickView.Status.Ready)
+        with patch("viewer.main_window.QQuickView.Status.Ready", "READY"):
+            win._on_qml_ready("READY")
         # assert
         value = [args[0][1] for args in root.setProperty.call_args_list if args[0][0] == "stepToolEnabled"][-1]
         self.assertIs(type(value), bool)
@@ -446,6 +333,7 @@ class TestMainWindowSlots(TestCase):
         win._last_status_time = 0.0
         win.statusBar = MagicMock(return_value=MagicMock())
         chart = MagicMock()
+        chart.abscissa_value_at_cursor.return_value = 0.35
         chart.ordinate_values_at_abscissa_value.return_value = [("V(out)", "V", [1.23])]
         win._charts = [chart]
         # act
@@ -475,12 +363,13 @@ class TestMainWindowSlots(TestCase):
         status_bar = MagicMock()
         win.statusBar = MagicMock(return_value=status_bar)
         chart = MagicMock()
+        chart.abscissa_value_at_cursor.return_value = 5.0
         chart.ordinate_values_at_abscissa_value.return_value = [("V(out)", "V", [1.0])]
         win._charts = [chart]
         # act
         win._on_pointer_moved(0, 0.2)
         # assert
-        status_bar.showMessage.assert_called_once_with("time = 5.00 s    V(out) = 1.00 V")
+        status_bar.showMessage.assert_called_once_with("time = 5.00 s  V(out) = 1.00 V")
 
 
 class TestMultiStepFft(TestCase):
@@ -488,15 +377,21 @@ class TestMultiStepFft(TestCase):
     def _make_fft_win(self, steps: int, step_points: int):
         # build a bare MainWindow bypassing __init__
         win = MainWindow.__new__(MainWindow)
-        win._abscissa = MagicMock(data=np.linspace(0.0, 1e-3, step_points), unit="s")
+        # create a multi-step abscissa vector with one step per block
+        abscissa_data = np.concatenate([np.linspace(float(step) * 1e-3, float(step + 1) * 1e-3, step_points, endpoint=False) for step in range(steps)])
+        win._abscissa = MagicMock(data=abscissa_data, unit="s")
         win._abscissa.name = "Time"
         win._abscissa_from_index = 0
-        win._abscissa_to_index = step_points
+        win._abscissa_to_index = steps * step_points
         win._steps = steps
         win._qraw_path = MagicMock()
         win._fft_windows = []
         win._charts = []
         win._abscissa_scale = MagicMock()
+        # build step information matching the multi-step abscissa layout
+        abscissa_indices = [slice(step * step_points, (step + 1) * step_points) for step in range(steps)]
+        abscissa_value_ranges = [(float(abscissa_data[s.start]), float(abscissa_data[s.stop - 1])) for s in abscissa_indices]
+        win._step_information = StepInformation([], [()] * steps, abscissa_indices, abscissa_value_ranges)
         return win
 
     def _make_dialog_mock(self, expr: Expression, step_points: int):
@@ -527,6 +422,7 @@ class TestMultiStepFft(TestCase):
         data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
         expr = Expression("V(out)", data, "V")
         chart = MagicMock()
+        chart.zoom_window = (None, None, None, None)
         chart.expressions = [expr]
         chart.abscissa = win._abscissa
         chart.selected_steps = {0, 1, 2}
@@ -543,16 +439,16 @@ class TestMultiStepFft(TestCase):
             win2._initial_selected_steps = None
             return win2
 
-        with patch("viewer.main_window.FftDialog", dialog_class), \
-             patch("viewer.main_window.QRawFile", fake_qraw), \
-             patch("viewer.main_window.MainWindow", fake_main_window), \
-             patch("viewer.main_window.compute_fft_many") as mock_fft, \
-             patch("viewer.main_window.ExpressionManager"):
-            freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((steps, 33)))
-            win._on_menu_fft(0)
-        # assert — one batched call computes all steps at once
-        self.assertEqual(mock_fft.call_count, 1)
+        with patch("viewer.main_window.FftDialog", dialog_class):
+            with patch("viewer.main_window.QRawFile", fake_qraw):
+                with patch("viewer.main_window.MainWindow", fake_main_window):
+                    with patch("viewer.main_window.compute_fft_many") as mock_fft:
+                        with patch("viewer.main_window.ExpressionManager"):
+                            freq = np.linspace(0, 500, 33)
+                            mock_fft.return_value = (freq, np.ones((1, 33)))
+                            win._on_menu_fft(0)
+        # assert — one FFT call is issued per source step
+        self.assertEqual(mock_fft.call_count, steps)
 
     def test_fft_batches_all_steps_and_expressions_in_single_matrix(self):
         # arrange
@@ -562,6 +458,7 @@ class TestMultiStepFft(TestCase):
         expr_a = Expression("V(a)", np.concatenate([np.full(step_points, 10.0 + s) for s in range(steps)]), "V")
         expr_b = Expression("V(b)", np.concatenate([np.full(step_points, 20.0 + s) for s in range(steps)]), "V")
         chart = MagicMock()
+        chart.zoom_window = (None, None, None, None)
         chart.expressions = [expr_a, expr_b]
         chart.abscissa = win._abscissa
         chart.selected_steps = {0, 1, 2}
@@ -575,22 +472,18 @@ class TestMultiStepFft(TestCase):
             captured_matrix.append(y_matrix.copy())
             return np.linspace(0, 500, 5), np.ones((y_matrix.shape[0], 5))
 
-        with patch("viewer.main_window.FftDialog", dialog_class), \
-             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
-             patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)), \
-             patch("viewer.main_window.compute_fft_many", side_effect=fake_fft), \
-             patch("viewer.main_window.ExpressionManager"):
-            win._on_menu_fft(0)
-        # assert — matrix rows are expression-major with all steps included
-        self.assertEqual(len(captured_matrix), 1)
-        y_matrix = captured_matrix[0]
-        self.assertEqual(y_matrix.shape, (steps * 2, step_points))
-        np.testing.assert_array_equal(y_matrix[0], np.full(step_points, 10.0))
-        np.testing.assert_array_equal(y_matrix[1], np.full(step_points, 11.0))
-        np.testing.assert_array_equal(y_matrix[2], np.full(step_points, 12.0))
-        np.testing.assert_array_equal(y_matrix[3], np.full(step_points, 20.0))
-        np.testing.assert_array_equal(y_matrix[4], np.full(step_points, 21.0))
-        np.testing.assert_array_equal(y_matrix[5], np.full(step_points, 22.0))
+        with patch("viewer.main_window.FftDialog", dialog_class):
+            with patch("viewer.main_window.QRawFile", return_value=MagicMock()):
+                with patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)):
+                    with patch("viewer.main_window.compute_fft_many", side_effect=fake_fft):
+                        with patch("viewer.main_window.ExpressionManager"):
+                            win._on_menu_fft(0)
+        # assert — one matrix is passed to FFT per source step
+        self.assertEqual(len(captured_matrix), steps)
+        for step_index, matrix in enumerate(captured_matrix):
+            self.assertEqual(matrix.shape, (2, step_points))
+            np.testing.assert_array_equal(matrix[0], np.full(step_points, 10.0 + step_index))
+            np.testing.assert_array_equal(matrix[1], np.full(step_points, 20.0 + step_index))
 
     def test_fft_qraw_built_with_all_steps(self):
         # arrange
@@ -600,6 +493,7 @@ class TestMultiStepFft(TestCase):
         data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
         expr = Expression("V(out)", data, "V")
         chart = MagicMock()
+        chart.zoom_window = (None, None, None, None)
         chart.expressions = [expr]
         chart.abscissa = win._abscissa
         chart.selected_steps = {1, 2}
@@ -608,7 +502,7 @@ class TestMultiStepFft(TestCase):
         captured_steps = []
 
         def fake_qraw(**kw):
-            captured_steps.append(kw.get("steps"))
+            captured_steps.append(kw.get("step_information"))
             return MagicMock()
 
         def fake_main_window(qraw, source_qraw_path=None):
@@ -616,16 +510,16 @@ class TestMultiStepFft(TestCase):
             win2._initial_selected_steps = None
             return win2
 
-        with patch("viewer.main_window.FftDialog", dialog_class), \
-             patch("viewer.main_window.QRawFile", fake_qraw), \
-             patch("viewer.main_window.MainWindow", fake_main_window), \
-             patch("viewer.main_window.compute_fft_many") as mock_fft, \
-             patch("viewer.main_window.ExpressionManager"):
-            freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((steps, 33)))
-            win._on_menu_fft(0)
-        # assert — QRawFile receives steps=3 (all source steps, not just selected)
-        self.assertEqual(captured_steps[0], steps)
+        with patch("viewer.main_window.FftDialog", dialog_class):
+            with patch("viewer.main_window.QRawFile", fake_qraw):
+                with patch("viewer.main_window.MainWindow", fake_main_window):
+                    with patch("viewer.main_window.compute_fft_many") as mock_fft:
+                        with patch("viewer.main_window.ExpressionManager"):
+                            freq = np.linspace(0, 500, 33)
+                            mock_fft.return_value = (freq, np.ones((1, 33)))
+                            win._on_menu_fft(0)
+        # assert — QRawFile receives step information for all source steps
+        self.assertEqual(captured_steps[0].length, steps)
 
     def test_fft_window_initial_selected_steps_matches_source_chart(self):
         # arrange
@@ -635,6 +529,7 @@ class TestMultiStepFft(TestCase):
         data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
         expr = Expression("V(out)", data, "V")
         chart = MagicMock()
+        chart.zoom_window = (None, None, None, None)
         chart.expressions = [expr]
         chart.abscissa = win._abscissa
         chart.selected_steps = {1, 2}
@@ -648,14 +543,14 @@ class TestMultiStepFft(TestCase):
             created_windows.append(win2)
             return win2
 
-        with patch("viewer.main_window.FftDialog", dialog_class), \
-             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
-             patch("viewer.main_window.MainWindow", fake_main_window), \
-             patch("viewer.main_window.compute_fft_many") as mock_fft, \
-             patch("viewer.main_window.ExpressionManager"):
-            freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((steps, 33)))
-            win._on_menu_fft(0)
+        with patch("viewer.main_window.FftDialog", dialog_class):
+            with patch("viewer.main_window.QRawFile", return_value=MagicMock()):
+                with patch("viewer.main_window.MainWindow", fake_main_window):
+                    with patch("viewer.main_window.compute_fft_many") as mock_fft:
+                        with patch("viewer.main_window.ExpressionManager"):
+                            freq = np.linspace(0, 500, 33)
+                            mock_fft.return_value = (freq, np.ones((steps, 33)))
+                            win._on_menu_fft(0)
         # assert — FFT window initial step selection matches source chart selected steps
         self.assertEqual(created_windows[0]._initial_selected_steps, {1, 2})
 
@@ -667,6 +562,7 @@ class TestMultiStepFft(TestCase):
         data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
         expr = Expression("V(out)", data, "V")
         chart = MagicMock()
+        chart.zoom_window = (None, None, None, None)
         chart.expressions = [expr]
         chart.abscissa = win._abscissa
         chart.selected_steps = {0, 1}
@@ -680,15 +576,15 @@ class TestMultiStepFft(TestCase):
             created_windows.append(win2)
             return win2
 
-        with patch("viewer.main_window.FftDialog", dialog_class), \
-             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
-             patch("viewer.main_window.MainWindow", fake_main_window), \
-             patch("viewer.main_window.compute_fft_many") as mock_fft, \
-             patch("viewer.main_window.ExpressionManager"), \
-             patch("viewer.main_window._register_child_window") as mock_register:
-            freq = np.linspace(0, 500, 33)
-            mock_fft.return_value = (freq, np.ones((steps, 33)))
-            win._on_menu_fft(0)
+        with patch("viewer.main_window.FftDialog", dialog_class):
+            with patch("viewer.main_window.QRawFile", return_value=MagicMock()):
+                with patch("viewer.main_window.MainWindow", fake_main_window):
+                    with patch("viewer.main_window.compute_fft_many") as mock_fft:
+                        with patch("viewer.main_window.ExpressionManager"):
+                            with patch("viewer.main_window._register_child_window") as mock_register:
+                                freq = np.linspace(0, 500, 33)
+                                mock_fft.return_value = (freq, np.ones((steps, 33)))
+                                win._on_menu_fft(0)
         # assert
         mock_register.assert_called_once_with(created_windows[0])
 
@@ -701,6 +597,7 @@ class TestMultiStepFft(TestCase):
         data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
         expr = Expression("V(out)", data, "V")
         chart = MagicMock()
+        chart.zoom_window = (None, None, None, None)
         chart.expressions = [expr]
         chart.abscissa = win._abscissa
         chart.selected_steps = {0, 1}
@@ -712,19 +609,19 @@ class TestMultiStepFft(TestCase):
             captured_expressions.extend(expressions)
             return MagicMock()
 
-        with patch("viewer.main_window.FftDialog", dialog_class), \
-             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
-             patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)), \
-             patch("viewer.main_window.compute_fft_many") as mock_fft, \
-             patch("viewer.main_window.ExpressionManager", fake_expr_mgr):
-            freq = np.linspace(0, 500, freq_points)
-            mock_fft.return_value = (freq, np.ones((steps, freq_points)))
-            win._on_menu_fft(0)
-        # assert — FFT expression data length = steps * freq_points; abscissa = freq_points only
+        with patch("viewer.main_window.FftDialog", dialog_class):
+            with patch("viewer.main_window.QRawFile", return_value=MagicMock()):
+                with patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)):
+                    with patch("viewer.main_window.compute_fft_many") as mock_fft:
+                        with patch("viewer.main_window.ExpressionManager", fake_expr_mgr):
+                            freq = np.linspace(0, 500, freq_points)
+                            mock_fft.return_value = (freq, np.ones((1, freq_points)))
+                            win._on_menu_fft(0)
+        # assert — FFT expression data length = steps * freq_points; frequency axis is repeated per step
         fft_expr = [e for e in captured_expressions if e.name != "Frequency"][0]
         abscissa_expr = [e for e in captured_expressions if e.name == "Frequency"][0]
         self.assertEqual(len(fft_expr.data), steps * freq_points)
-        self.assertEqual(len(abscissa_expr.data), freq_points)
+        self.assertEqual(len(abscissa_expr.data), steps * freq_points)
 
     def test_fft_expression_data_preserves_step_order(self):
         # arrange
@@ -735,6 +632,7 @@ class TestMultiStepFft(TestCase):
         data = np.concatenate([np.full(step_points, float(s)) for s in range(steps)])
         expr = Expression("V(out)", data, "V")
         chart = MagicMock()
+        chart.zoom_window = (None, None, None, None)
         chart.expressions = [expr]
         chart.abscissa = win._abscissa
         chart.selected_steps = {0, 1, 2}
@@ -746,17 +644,20 @@ class TestMultiStepFft(TestCase):
             captured_expressions.extend(expressions)
             return MagicMock()
 
+        step_counter = {"index": 0}
+
         def fake_fft(x, y_matrix, *args, **kwargs):
-            # one row per step for this single expression; emit distinct value per row
-            row_values = np.array([np.full(freq_points, float(row_index)) for row_index in range(y_matrix.shape[0])])
-            return np.linspace(0, 500, freq_points), row_values
+            # one row per step for this single expression; emit a value unique to the current step
+            current_step = step_counter["index"]
+            step_counter["index"] += 1
+            return np.linspace(0, 500, freq_points), np.array([np.full(freq_points, float(current_step))])
         # act
-        with patch("viewer.main_window.FftDialog", dialog_class), \
-             patch("viewer.main_window.QRawFile", return_value=MagicMock()), \
-             patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)), \
-             patch("viewer.main_window.compute_fft_many", side_effect=fake_fft), \
-             patch("viewer.main_window.ExpressionManager", fake_expr_mgr):
-            win._on_menu_fft(0)
+        with patch("viewer.main_window.FftDialog", dialog_class):
+            with patch("viewer.main_window.QRawFile", return_value=MagicMock()):
+                with patch("viewer.main_window.MainWindow", return_value=MagicMock(_initial_selected_steps=None)):
+                    with patch("viewer.main_window.compute_fft_many", side_effect=fake_fft):
+                        with patch("viewer.main_window.ExpressionManager", fake_expr_mgr):
+                            win._on_menu_fft(0)
         # assert — each step segment in the output buffer matches that step's value
         fft_expr = [e for e in captured_expressions if e.name != "Frequency"][0]
         for s in range(steps):

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -361,6 +361,56 @@ class TestMainWindowSlots(TestCase):
         mock_register.assert_called_once_with(created_window)
         created_window.show.assert_called_once_with()
 
+    def test_menu_open_file_creates_secondary_main_window(self):
+        # arrange
+        win = self._make_win()
+        created_window = MagicMock()
+        # act
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/example.qraw", "QRAW Files (*.qraw)")), \
+             patch("viewer.main_window.open_qraw_as_window", return_value=created_window) as mock_open, \
+             patch("viewer.main_window._register_child_window") as mock_register:
+            win._on_menu_open_file()
+        # assert
+        mock_open.assert_called_once()
+        mock_register.assert_called_once_with(created_window)
+        created_window.show.assert_called_once_with()
+
+    def test_menu_open_file_canceled(self):
+        # arrange
+        win = self._make_win()
+        # act
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("", "QRAW Files (*.qraw)")), \
+             patch("viewer.main_window.open_qraw_as_window") as mock_open, \
+             patch("viewer.main_window._register_child_window") as mock_register:
+            win._on_menu_open_file()
+        # assert
+        mock_open.assert_not_called()
+        mock_register.assert_not_called()
+
+    def test_menu_open_file_load_failure(self):
+        # arrange
+        win = self._make_win()
+        # act
+        with patch("viewer.main_window.QFileDialog.getOpenFileName", return_value=("/tmp/bad.qraw", "QRAW Files (*.qraw)")), \
+             patch("viewer.main_window.open_qraw_as_window", return_value=None) as mock_open, \
+             patch("viewer.main_window._register_child_window") as mock_register:
+            win._on_menu_open_file()
+        # assert
+        mock_open.assert_called_once()
+        mock_register.assert_not_called()
+
+    def test_menu_open_file_ignores_reentry_while_dialog_active(self):
+        # arrange
+        win = self._make_win()
+        # act
+        with patch("viewer.main_window._OPEN_FILE_DIALOG_ACTIVE", True), \
+             patch("viewer.main_window.QFileDialog.getOpenFileName") as mock_dialog, \
+             patch("viewer.main_window.open_qraw_as_window") as mock_open:
+            win._on_menu_open_file()
+        # assert
+        mock_dialog.assert_not_called()
+        mock_open.assert_not_called()
+
     def test_on_qml_ready_sets_step_tool_enabled_for_stepped_files(self):
         # arrange
         win = self._make_win()

--- a/tests/main_window_test.py
+++ b/tests/main_window_test.py
@@ -480,14 +480,12 @@ class TestMainWindowSlots(TestCase):
         win._last_status_time = 0.0
         win.statusBar = MagicMock(return_value=MagicMock())
         chart = MagicMock()
-        chart.sample_index_at_ratio.return_value = 7
-        chart.sample_at.return_value = [("V(out)", "V", [1.23])]
+        chart.ordinate_values_at_abscissa_value.return_value = [("V(out)", "V", [1.23])]
         win._charts = [chart]
         # act
         win._on_pointer_moved(0, 0.35)
         # assert
-        chart.sample_index_at_ratio.assert_called_once_with(0.35)
-        chart.sample_at.assert_called_once_with(0.35)
+        chart.ordinate_values_at_abscissa_value.assert_called_once_with(0.35)
 
     def test_pointer_moved_ignores_invalid_chart_index(self):
         # arrange
@@ -499,8 +497,7 @@ class TestMainWindowSlots(TestCase):
         # act
         win._on_pointer_moved(99, 0.5)
         # assert
-        chart.sample_index_at_ratio.assert_not_called()
-        chart.sample_at.assert_not_called()
+        chart.ordinate_values_at_abscissa_value.assert_not_called()
 
     def test_pointer_moved_updates_status_bar_message(self):
         # arrange
@@ -512,8 +509,7 @@ class TestMainWindowSlots(TestCase):
         status_bar = MagicMock()
         win.statusBar = MagicMock(return_value=status_bar)
         chart = MagicMock()
-        chart.sample_index_at_ratio.return_value = 5
-        chart.sample_at.return_value = [("V(out)", "V", [1.0])]
+        chart.ordinate_values_at_abscissa_value.return_value = [("V(out)", "V", [1.0])]
         win._charts = [chart]
         # act
         win._on_pointer_moved(0, 0.2)

--- a/tests/qraw_file_test.py
+++ b/tests/qraw_file_test.py
@@ -545,7 +545,7 @@ class TestProcessSteps(TestCase):
         # assert
         self.assertEqual(result.length, 1)
         self.assertEqual(result.abscissa_indices[0], slice(0, 3))
-        self.assertEqual(result.step_length(0), 3)
+        self.assertEqual(result.abscissa_indices[0].stop - result.abscissa_indices[0].start, 3)
         self.assertEqual(result.keys, [])
         self.assertEqual(result.values, [])
 
@@ -560,7 +560,7 @@ class TestProcessSteps(TestCase):
         # assert
         self.assertEqual(result.length, 1)
         self.assertEqual(result.abscissa_indices[0], slice(0, 3))
-        self.assertEqual(result.step_length(0), 3)
+        self.assertEqual(result.abscissa_indices[0].stop - result.abscissa_indices[0].start, 3)
         self.assertEqual(result.keys, [])
         self.assertEqual(result.values, [])
 
@@ -580,8 +580,8 @@ class TestProcessSteps(TestCase):
         self.assertEqual(result.values, [(1.0,), (2.0,)])
         self.assertEqual(result.abscissa_indices[0], slice(0, 3))
         self.assertEqual(result.abscissa_indices[1], slice(3, 6))
-        self.assertEqual(result.step_length(0), 3)
-        self.assertEqual(result.step_length(1), 3)
+        self.assertEqual(result.abscissa_indices[0].stop - result.abscissa_indices[0].start, 3)
+        self.assertEqual(result.abscissa_indices[1].stop - result.abscissa_indices[1].start, 3)
 
     def test_stepped_single_parameter_three_steps(self):
         # arrange
@@ -597,9 +597,9 @@ class TestProcessSteps(TestCase):
         self.assertEqual(result.length, 3)
         self.assertEqual(result.keys, ["R1"])
         self.assertEqual(result.values, [(1.0,), (2.0,), (3.0,)])
-        self.assertEqual(result.step_length(0), 2)
-        self.assertEqual(result.step_length(1), 2)
-        self.assertEqual(result.step_length(2), 2)
+        self.assertEqual(result.abscissa_indices[0].stop - result.abscissa_indices[0].start, 2)
+        self.assertEqual(result.abscissa_indices[1].stop - result.abscissa_indices[1].start, 2)
+        self.assertEqual(result.abscissa_indices[2].stop - result.abscissa_indices[2].start, 2)
 
     def test_stepped_multiple_parameters_two_steps(self):
         # arrange
@@ -632,8 +632,8 @@ class TestProcessSteps(TestCase):
         result = _process_steps(stepped, expressions, expr_voltage, num_points)
         # assert
         self.assertEqual(result.length, 2)
-        self.assertEqual(result.step_length(0), 2)
-        self.assertEqual(result.step_length(1), 4)
+        self.assertEqual(result.abscissa_indices[0].stop - result.abscissa_indices[0].start, 2)
+        self.assertEqual(result.abscissa_indices[1].stop - result.abscissa_indices[1].start, 4)
         self.assertEqual(result.values, [(1.0, 10.0), (2.0, 20.0)])
 
     def test_parameter_values_extracted_at_step_start(self):
@@ -662,9 +662,9 @@ class TestProcessSteps(TestCase):
         result = _process_steps(stepped, expressions, expr_voltage, num_points)
         # assert
         self.assertEqual(result.length, 3)
-        self.assertEqual(result.step_length(0), 1)
-        self.assertEqual(result.step_length(1), 1)
-        self.assertEqual(result.step_length(2), 1)
+        self.assertEqual(result.abscissa_indices[0].stop - result.abscissa_indices[0].start, 1)
+        self.assertEqual(result.abscissa_indices[1].stop - result.abscissa_indices[1].start, 1)
+        self.assertEqual(result.abscissa_indices[2].stop - result.abscissa_indices[2].start, 1)
 
     def test_large_number_of_steps(self):
         # arrange
@@ -679,7 +679,8 @@ class TestProcessSteps(TestCase):
         # assert
         self.assertEqual(result.length, 20)
         for i in range(20):
-            self.assertEqual(result.step_length(i), 5)
+            step_slice = result.abscissa_indices[i]
+            self.assertEqual(step_slice.stop - step_slice.start, 5)
 
     def test_keys_match_parameter_names(self):
         # arrange
@@ -725,7 +726,7 @@ class TestProcessSteps(TestCase):
         # act
         result = _process_steps(stepped, expressions, expr_voltage, num_points)
         # assert
-        total_length = sum(result.step_length(i) for i in range(result.length))
+        total_length = sum(step_slice.stop - step_slice.start for step_slice in result.abscissa_indices)
         self.assertEqual(total_length, num_points)
 
     def test_step_information_uses_primitive_types_for_lengths_and_slices(self):
@@ -744,7 +745,7 @@ class TestProcessSteps(TestCase):
             step_slice = result.abscissa_indices[i]
             self.assertIsInstance(step_slice.start, int)
             self.assertIsInstance(step_slice.stop, int)
-            self.assertIsInstance(result.step_length(i), int)
+            self.assertIsInstance(step_slice.stop - step_slice.start, int)
 
     def test_step_information_values_tuples_use_python_primitives(self):
         # arrange
@@ -784,7 +785,7 @@ class TestProcessSteps(TestCase):
         self.assertEqual(result.step_abscissa_left_value(2), 11.0)
         self.assertEqual(result.step_abscissa_right_value(2), 1001.0)
 
-    def test_step_information_stores_global_abscissa_value_bounds(self):
+    def test_step_information_stores_global_abscissa_axis_sides(self):
         # arrange
         stepped = True
         abscissa = Expression("Time", np.array([10.0, 20.0, 30.0, 9.0, 100.0, 998.0, 11.0, 501.0, 1001.0]), "s", variable_type="time")
@@ -798,6 +799,49 @@ class TestProcessSteps(TestCase):
         # assert
         self.assertEqual(result.abscissa_left_value, 9.0)
         self.assertEqual(result.abscissa_right_value, 1001.0)
+
+    def test_step_information_stores_descending_abscissa_axis_sides(self):
+        # arrange
+        stepped = True
+        abscissa = Expression("Frequency", np.array([100.0, 10.0, 1.0, 200.0, 20.0, 2.0]), "Hz", variable_type="frequency")
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+        expr_param = Expression("Step", param_data, "", variable_type="parameter")
+        expr_gain = Expression("V(out)", np.arange(6, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_gain, expr_param]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, abscissa, num_points)
+        # assert
+        self.assertEqual(result.abscissa_left_value, 200.0)
+        self.assertEqual(result.abscissa_right_value, 1.0)
+
+    def test_step_information_marks_descending_abscissa_orientation(self):
+        # arrange
+        stepped = True
+        abscissa = Expression("Frequency", np.array([100.0, 10.0, 1.0, 200.0, 20.0, 2.0]), "Hz", variable_type="frequency")
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+        expr_param = Expression("Step", param_data, "", variable_type="parameter")
+        expr_gain = Expression("V(out)", np.arange(6, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_gain, expr_param]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, abscissa, num_points)
+        # assert
+        self.assertFalse(result.abscissa_ascending)
+
+    def test_step_information_marks_ascending_abscissa_orientation(self):
+        # arrange
+        stepped = True
+        abscissa = Expression("Frequency", np.array([1.0, 10.0, 100.0, 2.0, 20.0, 200.0]), "Hz", variable_type="frequency")
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+        expr_param = Expression("Step", param_data, "", variable_type="parameter")
+        expr_gain = Expression("V(out)", np.arange(6, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_gain, expr_param]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, abscissa, num_points)
+        # assert
+        self.assertTrue(result.abscissa_ascending)
 
     def test_all_points_covered_by_slices(self):
         # arrange

--- a/tests/qraw_file_test.py
+++ b/tests/qraw_file_test.py
@@ -777,12 +777,12 @@ class TestProcessSteps(TestCase):
         # act
         result = _process_steps(stepped, expressions, abscissa, num_points)
         # assert
-        self.assertEqual(result.step_abscissa_from_value(0), 10.0)
-        self.assertEqual(result.step_abscissa_to_value(0), 30.0)
-        self.assertEqual(result.step_abscissa_from_value(1), 9.0)
-        self.assertEqual(result.step_abscissa_to_value(1), 998.0)
-        self.assertEqual(result.step_abscissa_from_value(2), 11.0)
-        self.assertEqual(result.step_abscissa_to_value(2), 1001.0)
+        self.assertEqual(result.step_abscissa_left_value(0), 10.0)
+        self.assertEqual(result.step_abscissa_right_value(0), 30.0)
+        self.assertEqual(result.step_abscissa_left_value(1), 9.0)
+        self.assertEqual(result.step_abscissa_right_value(1), 998.0)
+        self.assertEqual(result.step_abscissa_left_value(2), 11.0)
+        self.assertEqual(result.step_abscissa_right_value(2), 1001.0)
 
     def test_step_information_stores_global_abscissa_value_bounds(self):
         # arrange
@@ -796,8 +796,8 @@ class TestProcessSteps(TestCase):
         # act
         result = _process_steps(stepped, expressions, abscissa, num_points)
         # assert
-        self.assertEqual(result.abscissa_from_value, 9.0)
-        self.assertEqual(result.abscissa_to_value, 1001.0)
+        self.assertEqual(result.abscissa_left_value, 9.0)
+        self.assertEqual(result.abscissa_right_value, 1001.0)
 
     def test_all_points_covered_by_slices(self):
         # arrange

--- a/tests/qraw_file_test.py
+++ b/tests/qraw_file_test.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 import numpy as np
 
 from viewer.expression import Expression
-from viewer.qraw_file import (AbscissaScale, PlotSuggestion, QRawFile, VariableType, VariableTypeInformation, _process_scale, _process_step)
+from viewer.qraw_file import (AbscissaScale, PlotSuggestion, QRawFile, VariableType, VariableTypeInformation, _process_scale, _process_steps)
 
 FIXTURES_DIR = Path(__file__).parent / "PyQSPICE"
 
@@ -381,13 +381,14 @@ class TestQRawFile(TestCase):
         # assert — time axis must always advance forward
         self.assertTrue(np.all(np.diff(qraw.abscissa.data) >= 0))
 
-    def test_abscissa_data_is_monotonically_increasing_for_ac(self):
+    def test_abscissa_data_is_monotonically_increasing_within_each_ac_step(self):
         # arrange
         filename = FIXTURES_DIR / "VRM_GainBW.qraw"
         # act
         qraw = QRawFile.load(filename)
-        # assert — log10 frequency axis must always advance forward
-        self.assertTrue(np.all(np.diff(qraw.abscissa.data) >= 0))
+        # assert — log10 frequency axis must always advance forward within each step
+        for step_slice in qraw.step_information.abscissa_indices:
+            self.assertTrue(np.all(np.diff(qraw.abscissa.data[step_slice]) >= 0))
 
     def test_abscissa_variable_type_is_time_for_transient(self):
         # arrange
@@ -481,47 +482,6 @@ class TestQRawFileLoad(TestCase):
         self.assertIsNotNone(result)
 
 
-class TestProcessStep(TestCase):
-
-    def test_detects_correct_number_of_steps(self):
-        # arrange — 3 steps of 4 points each; first value repeats at index 4 and 8
-        data = np.array([0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0])
-        abscissa = Expression("Time", data, "s")
-        # act
-        steps, trimmed = _process_step(abscissa, len(data))
-        # assert
-        self.assertEqual(steps, 3)
-
-    def test_returns_abscissa_trimmed_to_one_period(self):
-        # arrange — 3 steps of 4 points each
-        data = np.array([0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0])
-        abscissa = Expression("Time", data, "s")
-        # act
-        steps, trimmed = _process_step(abscissa, len(data))
-        # assert — trimmed abscissa must be one period (4 points)
-        self.assertEqual(len(trimmed.data), 4)
-        np.testing.assert_array_equal(trimmed.data, data[:4])
-
-    def test_preserves_abscissa_name_and_unit(self):
-        # arrange
-        data = np.array([0.0, 1.0, 0.0, 1.0])
-        abscissa = Expression("Time", data, "s")
-        # act
-        _, trimmed = _process_step(abscissa, len(data))
-        # assert
-        self.assertEqual(trimmed.name, "Time")
-        self.assertEqual(trimmed.unit, "s")
-
-    def test_two_steps_returns_step_count_of_two(self):
-        # arrange — 2 steps of 3 points each; abscissa[0] reappears at index 3
-        data = np.array([0.0, 1.0, 2.0, 0.0, 1.0, 2.0])
-        abscissa = Expression("Time", data, "s")
-        # act
-        steps, _ = _process_step(abscissa, len(data))
-        # assert
-        self.assertEqual(steps, 2)
-
-
 class TestProcessScale(TestCase):
 
     def test_decade_applies_log10(self):
@@ -570,6 +530,361 @@ class TestProcessScale(TestCase):
         # assert
         self.assertEqual(result.name, "Frequency")
         self.assertEqual(result.unit, "Hz")
+
+
+class TestProcessSteps(TestCase):
+
+    def test_non_stepped_returns_single_step(self):
+        # arrange
+        stepped = False
+        expr_voltage = Expression("V(out)", np.array([1.0, 2.0, 3.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage]
+        num_points = 3
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 1)
+        self.assertEqual(result.abscissa_indices[0], slice(0, 3))
+        self.assertEqual(result.step_length(0), 3)
+        self.assertEqual(result.keys, [])
+        self.assertEqual(result.values, [])
+
+    def test_stepped_no_parameters_returns_single_step(self):
+        # arrange
+        stepped = True
+        expr_voltage = Expression("V(out)", np.array([1.0, 2.0, 3.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage]
+        num_points = 3
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 1)
+        self.assertEqual(result.abscissa_indices[0], slice(0, 3))
+        self.assertEqual(result.step_length(0), 3)
+        self.assertEqual(result.keys, [])
+        self.assertEqual(result.values, [])
+
+    def test_stepped_single_parameter_two_steps(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 2)
+        self.assertEqual(result.keys, ["R1"])
+        self.assertEqual(result.values, [(1.0,), (2.0,)])
+        self.assertEqual(result.abscissa_indices[0], slice(0, 3))
+        self.assertEqual(result.abscissa_indices[1], slice(3, 6))
+        self.assertEqual(result.step_length(0), 3)
+        self.assertEqual(result.step_length(1), 3)
+
+    def test_stepped_single_parameter_three_steps(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 2.0, 2.0, 3.0, 3.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 3)
+        self.assertEqual(result.keys, ["R1"])
+        self.assertEqual(result.values, [(1.0,), (2.0,), (3.0,)])
+        self.assertEqual(result.step_length(0), 2)
+        self.assertEqual(result.step_length(1), 2)
+        self.assertEqual(result.step_length(2), 2)
+
+    def test_stepped_multiple_parameters_two_steps(self):
+        # arrange
+        stepped = True
+        param1_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0])
+        param2_data = np.array([10.0, 10.0, 10.0, 20.0, 20.0, 20.0])
+        expr_param1 = Expression("R1", param1_data, "", variable_type="parameter")
+        expr_param2 = Expression("R2", param2_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param1, expr_param2]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 2)
+        self.assertEqual(result.keys, ["R1", "R2"])
+        self.assertEqual(result.values, [(1.0, 10.0), (2.0, 20.0)])
+
+    def test_stepped_multiple_parameters_unequal_steps(self):
+        # arrange — variable-length steps: 2 points in first step, 4 in second
+        stepped = True
+        param1_data = np.array([1.0, 1.0, 2.0, 2.0, 2.0, 2.0])
+        param2_data = np.array([10.0, 10.0, 20.0, 20.0, 20.0, 20.0])
+        expr_param1 = Expression("R1", param1_data, "", variable_type="parameter")
+        expr_param2 = Expression("R2", param2_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0, 500.0, 600.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param1, expr_param2]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 2)
+        self.assertEqual(result.step_length(0), 2)
+        self.assertEqual(result.step_length(1), 4)
+        self.assertEqual(result.values, [(1.0, 10.0), (2.0, 20.0)])
+
+    def test_parameter_values_extracted_at_step_start(self):
+        # arrange
+        stepped = True
+        param_data = np.array([5.5, 5.5, 5.5, 10.2, 10.2, 10.2])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0, 500.0, 600.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertAlmostEqual(result.values[0][0], 5.5)
+        self.assertAlmostEqual(result.values[1][0], 10.2)
+
+    def test_single_point_per_step(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 2.0, 3.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 3
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 3)
+        self.assertEqual(result.step_length(0), 1)
+        self.assertEqual(result.step_length(1), 1)
+        self.assertEqual(result.step_length(2), 1)
+
+    def test_large_number_of_steps(self):
+        # arrange
+        stepped = True
+        param_data = np.array([float(i // 5) for i in range(100)])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.ones(100), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 100
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 20)
+        for i in range(20):
+            self.assertEqual(result.step_length(i), 5)
+
+    def test_keys_match_parameter_names(self):
+        # arrange
+        stepped = True
+        param1_data = np.array([1.0, 1.0, 2.0, 2.0])
+        param2_data = np.array([10.0, 10.0, 20.0, 20.0])
+        expr_param1 = Expression("resistance", param1_data, "", variable_type="parameter")
+        expr_param2 = Expression("capacitance", param2_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param1, expr_param2]
+        num_points = 4
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.keys, ["resistance", "capacitance"])
+
+    def test_slice_boundaries_correct(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 3.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.arange(6, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 6
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.abscissa_indices[0].start, 0)
+        self.assertEqual(result.abscissa_indices[0].stop, 3)
+        self.assertEqual(result.abscissa_indices[1].start, 3)
+        self.assertEqual(result.abscissa_indices[1].stop, 5)
+        self.assertEqual(result.abscissa_indices[2].start, 5)
+        self.assertEqual(result.abscissa_indices[2].stop, 6)
+
+    def test_step_length_sum_equals_total_points(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.arange(7, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 7
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        total_length = sum(result.step_length(i) for i in range(result.length))
+        self.assertEqual(total_length, num_points)
+
+    def test_step_information_uses_primitive_types_for_lengths_and_slices(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 2.0, 2.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 4
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertIsInstance(result.length, int)
+        for i in range(result.length):
+            step_slice = result.abscissa_indices[i]
+            self.assertIsInstance(step_slice.start, int)
+            self.assertIsInstance(step_slice.stop, int)
+            self.assertIsInstance(result.step_length(i), int)
+
+    def test_step_information_values_tuples_use_python_primitives(self):
+        # arrange
+        stepped = True
+        param1_data = np.array([1.5, 1.5, 2.5, 2.5])
+        param2_data = np.array([10, 10, 20, 20])
+        expr_param1 = Expression("R1", param1_data, "", variable_type="parameter")
+        expr_param2 = Expression("R2", param2_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param1, expr_param2]
+        num_points = 4
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        for value_tuple in result.values:
+            self.assertIsInstance(value_tuple, tuple)
+            for value in value_tuple:
+                self.assertNotIsInstance(value, np.generic)
+                self.assertIsInstance(value, int | float | bool | str)
+
+    def test_step_information_stores_per_step_abscissa_value_ranges(self):
+        # arrange
+        stepped = True
+        abscissa = Expression("Time", np.array([10.0, 20.0, 30.0, 9.0, 100.0, 998.0, 11.0, 501.0, 1001.0]), "s", variable_type="time")
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.arange(9, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 9
+        # act
+        result = _process_steps(stepped, expressions, abscissa, num_points)
+        # assert
+        self.assertEqual(result.step_abscissa_from_value(0), 10.0)
+        self.assertEqual(result.step_abscissa_to_value(0), 30.0)
+        self.assertEqual(result.step_abscissa_from_value(1), 9.0)
+        self.assertEqual(result.step_abscissa_to_value(1), 998.0)
+        self.assertEqual(result.step_abscissa_from_value(2), 11.0)
+        self.assertEqual(result.step_abscissa_to_value(2), 1001.0)
+
+    def test_step_information_stores_global_abscissa_value_bounds(self):
+        # arrange
+        stepped = True
+        abscissa = Expression("Time", np.array([10.0, 20.0, 30.0, 9.0, 100.0, 998.0, 11.0, 501.0, 1001.0]), "s", variable_type="time")
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.arange(9, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 9
+        # act
+        result = _process_steps(stepped, expressions, abscissa, num_points)
+        # assert
+        self.assertEqual(result.abscissa_from_value, 9.0)
+        self.assertEqual(result.abscissa_to_value, 1001.0)
+
+    def test_all_points_covered_by_slices(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.arange(8, dtype=float), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 8
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert — all indices from 0 to num_points-1 must be covered exactly once
+        covered_indices = set()
+        for i in range(result.length):
+            s = result.abscissa_indices[i]
+            covered_indices.update(range(s.start, s.stop))
+        self.assertEqual(covered_indices, set(range(num_points)))
+
+    def test_floats_and_integers_in_parameter_values(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.5, 1.5, 2.7, 2.7])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage, expr_param]
+        num_points = 4
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(len(result.values), 2)
+        self.assertAlmostEqual(result.values[0][0], 1.5)
+        self.assertAlmostEqual(result.values[1][0], 2.7)
+
+    def test_parameter_at_end_of_sequence(self):
+        # arrange
+        stepped = True
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0]), "V", variable_type="voltage")
+        param_data = np.array([1.0, 1.0, 2.0, 2.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expressions = [expr_voltage, expr_param]
+        num_points = 4
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 2)
+        self.assertEqual(result.keys, ["R1"])
+
+    def test_parameter_at_beginning_of_sequence(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 2.0, 2.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0]), "V", variable_type="voltage")
+        expressions = [expr_param, expr_voltage]
+        num_points = 4
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 2)
+        self.assertEqual(result.keys, ["R1"])
+
+    def test_ignores_non_parameter_expressions(self):
+        # arrange
+        stepped = True
+        param_data = np.array([1.0, 1.0, 2.0, 2.0])
+        expr_param = Expression("R1", param_data, "", variable_type="parameter")
+        expr_voltage = Expression("V(out)", np.array([100.0, 200.0, 300.0, 400.0]), "V", variable_type="voltage")
+        expr_current = Expression("I(R1)", np.array([0.5, 0.5, 1.0, 1.0]), "A", variable_type="current")
+        expressions = [expr_voltage, expr_param, expr_current]
+        num_points = 4
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert — only parameter should determine steps, not voltage/current
+        self.assertEqual(result.length, 2)
+        self.assertEqual(result.keys, ["R1"])
+
+    def test_empty_parameters_with_non_stepped(self):
+        # arrange
+        stepped = False
+        expr_voltage = Expression("V(out)", np.array([1.0, 2.0]), "V", variable_type="voltage")
+        expressions = [expr_voltage]
+        num_points = 2
+        # act
+        result = _process_steps(stepped, expressions, expr_voltage, num_points)
+        # assert
+        self.assertEqual(result.length, 1)
+        self.assertEqual(result.keys, [])
 
 
 class TestVariableTypeInformation(TestCase):

--- a/tests/step_tool_dialog_test.py
+++ b/tests/step_tool_dialog_test.py
@@ -77,7 +77,7 @@ class TestStepToolDialog(TestCase):
         StepToolDialog.__init__.__globals__["QUrl"] = MagicMock(fromLocalFile=lambda value: value)
         StepToolDialog.__init__.__globals__["QColor"] = lambda value: value
         StepToolDialog.__init__.__globals__["Qt"] = MagicMock(WindowModality=MagicMock(WindowModal=object()))
-        step_information = StepInformation(keys=["temp", "vdd"], values=[(25, 1.8), (100, 3.3)], indices=[slice(0, 2), slice(2, 4)])
+        step_information = StepInformation(keys=["temp", "vdd"], values=[(25, 1.8), (100, 3.3)], abscissa_indices=[slice(0, 2), slice(2, 4)], abscissa_value_ranges=[(0.0, 1.0), (1.0, 2.0)])
         # act
         dialog = StepToolDialog(parent=MagicMock(), step_information=step_information, selected_steps={3, 1})
         # assert

--- a/tests/step_tool_dialog_test.py
+++ b/tests/step_tool_dialog_test.py
@@ -39,30 +39,43 @@ class TestStepToolDialog(TestCase):
         class _Signal:
             def connect(self, _slot):
                 return None
+
         class _FakeQuickView:
             class Status:
                 Ready = object()
+
             class ResizeMode:
                 SizeRootObjectToView = object()
+
             def __init__(self):
                 self.statusChanged = _Signal()
+
             def setResizeMode(self, _mode):
                 return None
+
             def setColor(self, _color):
                 return None
+
             def setSource(self, _source):
                 return None
+
             def rootObject(self):
                 return MagicMock()
+
         class _FakeWidget:
+
             @staticmethod
             def createWindowContainer(_view, _parent):
                 return object()
+
         class _FakeLayout:
+
             def __init__(self, _parent):
                 return None
+
             def setContentsMargins(self, _a, _b, _c, _d):
                 return None
+
             def addWidget(self, _widget):
                 return None
         original_qquickview = StepToolDialog.__init__.__globals__["QQuickView"]

--- a/viewer/__main__.py
+++ b/viewer/__main__.py
@@ -6,6 +6,7 @@ import warnings
 from PySide6.QtCore import QtMsgType, qInstallMessageHandler
 from PySide6.QtWidgets import QApplication, QFileDialog
 
+from viewer.app_open import open_qraw_as_window
 from viewer.main_window import load_app_icon, MainWindow
 from viewer.qraw_file import QRawFile
 
@@ -80,13 +81,11 @@ def main():
         # exit when the user cancels the dialog
         if not input_path:
             sys.exit(0)
-    # load and parse the QRAW file
-    qraw_file = QRawFile.load(input_path)
-    if qraw_file is None:
+    # load file and create the main window through shared open path
+    window = open_qraw_as_window(input_path, lambda qraw_file: MainWindow(qraw_file))
+    if window is None:
         # exit
         sys.exit(1)
-    # main window with the loaded QRAW file
-    window = MainWindow(qraw_file)
     # show the main window
     window.show()
     # enter the Qt application main loop

--- a/viewer/app_open.py
+++ b/viewer/app_open.py
@@ -1,0 +1,14 @@
+from collections.abc import Callable
+from pathlib import Path
+
+from .qraw_file import QRawFile
+
+
+def open_qraw_as_window(input_path: str | Path, window_factory: Callable[[QRawFile], object]) -> object | None:
+    # load and parse the QRAW file
+    qraw_file = QRawFile.load(input_path)
+    # return none when parsing fails
+    if qraw_file is None:
+        return None
+    # create the target window from the loaded qraw object
+    return window_factory(qraw_file)

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -91,10 +91,14 @@ class Chart:
 
     def render(self, abscissa_label: str, abscissa_scale: str, initial_expressions: set[Expression]):
         # abscissa data for the first step
-        abscissa_data = self._abscissa.data[self._step_information.abscissa_indices[0]]
+        first_step_slice = self._step_information.abscissa_indices[0]
+        # local zoom bounds for the first step
+        first_from_index, first_to_index = self._get_step_zoom_bounds(0)
+        # abscissa data for the first step and local zoom range
+        abscissa_data = self._abscissa.data[first_step_slice.start + first_from_index:first_step_slice.start + first_to_index]
         # x0 and x1 (from first step)
-        abscissa_left_value = float(abscissa_data[self._zoom_window[0]])
-        abscissa_right_value = float(abscissa_data[self._zoom_window[2] - 1])
+        abscissa_left_value = float(abscissa_data[0])
+        abscissa_right_value = float(abscissa_data[-1])
         # initialize chart component
         self._component.initialize(abscissa_label, self._abscissa.unit, abscissa_scale, abscissa_left_value, abscissa_right_value)
         # render all expressions as series
@@ -168,10 +172,15 @@ class Chart:
                         continue
                     # step slice
                     step_slice = self._step_information.abscissa_indices[step]
+                    # local zoom bounds for this step
+                    zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
                     # apply zoom window to abscissa
-                    abscissa_values = self._abscissa.data[step_slice][self._zoom_window[0]:self._zoom_window[2]]
+                    abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
                     # ordinate variant values for this step (as contiguous array in memory), apply zoom window
-                    ordinate_values = ordinate_variant.data[step_slice][self._zoom_window[0]:self._zoom_window[2]]
+                    ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
+                    # skip inconsistent slices to protect decimation input contracts
+                    if abscissa_values.size == 0 or ordinate_values.size == 0 or abscissa_values.size != ordinate_values.size:
+                        continue
                     # decimate x and y jointly so every plotted (x, y) pair maps to the same original sample
                     x_np, y_np = decimate_xy(abscissa_values, ordinate_values, self._decimate_target, _DECIMATION_ALGORITHM)
                     # remove Inf values
@@ -328,15 +337,15 @@ class Chart:
         x_ratio = max(0.0, min(1.0, x_ratio))
         # current horizontal zoom bounds
         from_index, to_index = self.zoom_abscissa_bounds()
-        # visible abscissa window
-        window = self._abscissa.data[from_index:to_index]
+        # reference step for x mapping, using the first selected step when available
+        reference_step = min(self._selected_steps) if self._selected_steps else 0
+        # reference step slice
+        reference_slice = self._step_information.abscissa_indices[reference_step]
+        # visible abscissa window for the reference step
+        window = self._abscissa.data[reference_slice.start + from_index:reference_slice.start + to_index]
         # check visible window is empty
         if window.size == 0:
             return []
-        # target abscissa value under the cursor in the visible window
-        target_x = float(window[0] + x_ratio * (window[-1] - window[0]))
-        # compute the nearest sample index within the current zoom window
-        idx = self.sample_index_at_ratio(x_ratio)
         # collect one (name, unit, value) tuple per plotted variant (magnitude/phase counted separately)
         result: list[tuple[str, str, list[float]]] = []
         # loop series
@@ -360,9 +369,28 @@ class Chart:
         # current abscissa bounds in sample indexes
         return self._zoom_window[0], self._zoom_window[2]
 
+    def _get_step_zoom_bounds(self, step: int) -> tuple[int, int]:
+        # step length for this step
+        step_length = self._step_information.step_length(step)
+        # keep at least two points when possible for stable zoom and FFT windows
+        if step_length <= 1:
+            return 0, step_length
+        # clamp zoom start to step bounds
+        from_index = max(0, min(self._zoom_window[0], step_length - 2))
+        # clamp zoom end to step bounds and enforce a minimum window size of two points
+        to_index = max(from_index + 2, min(self._zoom_window[2], step_length))
+        # return local bounds
+        return from_index, to_index
+
     def sample_index_at_ratio(self, x_ratio: float) -> int:
         # x zoom window indexes
         from_index, to_index = self.zoom_abscissa_bounds()
+        # reference step for x mapping, using the first selected step when available
+        reference_step = min(self._selected_steps) if self._selected_steps else 0
+        # clamp bounds to the reference step
+        from_index, to_index = self._get_step_zoom_bounds(reference_step)
+        # reference slice
+        reference_slice = self._step_information.abscissa_indices[reference_step]
         # clamp ratio to visible horizontal span
         x_ratio = max(0.0, min(1.0, x_ratio))
         # window length
@@ -372,7 +400,7 @@ class Chart:
             # return only sample index in window
             return from_index
         # visible abscissa window which can be non-uniformly spaced
-        window = self._abscissa.data[from_index:to_index]
+        window = self._abscissa.data[reference_slice.start + from_index:reference_slice.start + to_index]
         # target x value on the visible axis for the given cursor ratio
         target = float(window[0] + x_ratio * (window[-1] - window[0]))
         # check ascending abscissa ordering
@@ -418,6 +446,16 @@ class Chart:
         # select the closest index and break ties to the left
         return from_index + (left_idx if left_dist <= right_dist else right_idx)
 
+    def sample_abscissa_value_at_ratio(self, x_ratio: float) -> float:
+        # reference step for x mapping, using the first selected step when available
+        reference_step = min(self._selected_steps) if self._selected_steps else 0
+        # reference step slice
+        reference_slice = self._step_information.abscissa_indices[reference_step]
+        # nearest sample index within the current zoom window for the reference step
+        index = self.sample_index_at_ratio(x_ratio)
+        # return stored abscissa value
+        return float(self._abscissa.data[reference_slice.start + index])
+
     def _get_expressions_to_plot(self, expression: Expression) -> list[Expression]:
         # check we can plot expression as is
         if not expression.complex:
@@ -455,10 +493,15 @@ class Chart:
                     for step, series in rendered_series.items():
                         # step slice
                         step_slice = self._step_information.abscissa_indices[step]
+                        # local zoom bounds for this step
+                        zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
                         # abscissa values
-                        abscissa_values = self._abscissa.data[step_slice][self._zoom_window[0]:self._zoom_window[2]]
+                        abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
                         # ordinate variant values for this step & zoom window
-                        ordinate_values = ordinate_variant.data[step_slice][self._zoom_window[0]:self._zoom_window[2]]
+                        ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
+                        # skip inconsistent slices to protect decimation input contracts
+                        if abscissa_values.size == 0 or ordinate_values.size == 0 or abscissa_values.size != ordinate_values.size:
+                            continue
                         # decimate x and y jointly so every plotted (x, y) pair maps to the same original sample
                         x_np, y_np = decimate_xy(abscissa_values, ordinate_values, self._decimate_target, _DECIMATION_ALGORITHM)
                         # remove Inf values

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -172,8 +172,8 @@ class Chart:
         # current zoom window in abscissa values, None if not set
         x_left_ratio, _, x_right_ratio, _ = self._zoom_window
         # x0 and x1
-        abscissa_left_value = self.ratio_to_abscissa_value(x_left_ratio) if x_left_ratio is not None else self._step_information.abscissa_left_value
-        abscissa_right_value = self.ratio_to_abscissa_value(x_right_ratio) if x_right_ratio is not None else self._step_information.abscissa_right_value
+        abscissa_left_value = self._ratio_to_abscissa_value(x_left_ratio) if x_left_ratio is not None else self._step_information.abscissa_left_value
+        abscissa_right_value = self._ratio_to_abscissa_value(x_right_ratio) if x_right_ratio is not None else self._step_information.abscissa_right_value
         # loop expressions that should be plotted
         for ordinate in expressions:
             # lookup ordinate in series
@@ -406,9 +406,19 @@ class Chart:
         # exit
         return result
     
-    def ratio_to_abscissa_value(self, x_ratio: float) -> float:
+    def _ratio_to_abscissa_value(self, x_ratio: float) -> float:
         # make sure ratio is between 0 and 1
         percentage = max(0.0, min(1.0, x_ratio))
+        # convert to abscissa value
+        return self._step_information.abscissa_left_value + percentage * (self._step_information.abscissa_right_value - self._step_information.abscissa_left_value)
+    
+    def abscissa_value_at_cursor(self, cursor: float) -> float:
+        # make sure cursor is between 0 and 1
+        percentage = max(0.0, min(1.0, cursor))
+        # apply zoom window if it exists
+        if self._zoom_window[0] is not None and self._zoom_window[2] is not None:
+            # recalculate percentage based on zoom window
+            percentage = self._zoom_window[0] + percentage * (self._zoom_window[2] - self._zoom_window[0])
         # convert to abscissa value
         return self._step_information.abscissa_left_value + percentage * (self._step_information.abscissa_right_value - self._step_information.abscissa_left_value)
 
@@ -449,8 +459,8 @@ class Chart:
         # current zoom window in abscissa values, None if not set
         x_left_ratio, _, x_right_ratio, _ = self._zoom_window
         # x0 and x1
-        abscissa_left_value = self.ratio_to_abscissa_value(x_left_ratio) if x_left_ratio is not None else self._step_information.abscissa_left_value
-        abscissa_right_value = self.ratio_to_abscissa_value(x_right_ratio) if x_right_ratio is not None else self._step_information.abscissa_right_value
+        abscissa_left_value = self._ratio_to_abscissa_value(x_left_ratio) if x_left_ratio is not None else self._step_information.abscissa_left_value
+        abscissa_right_value = self._ratio_to_abscissa_value(x_right_ratio) if x_right_ratio is not None else self._step_information.abscissa_right_value
         try:
             # loop existing series
             for _, (_, ordinate_series) in self._series.items():

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -36,7 +36,7 @@ _SERIES_COLOR_PALETTE = [
 
 class Chart:
 
-    def __init__(self, component: QQuickItem, char_type: str, expression_manager: ExpressionManager, abscissa: Expression, abscissa_from_index: int, abscissa_to_index: int, step_information: StepInformation, decimate_target: int):
+    def __init__(self, component: QQuickItem, char_type: str, expression_manager: ExpressionManager, abscissa: Expression, step_information: StepInformation, decimate_target: int):
         # store component
         self._component = component
         # store chart type
@@ -46,7 +46,7 @@ class Chart:
         # store variables
         self._abscissa = abscissa
         # current zoom window (x: in abscissa index, y: in ordinate percentages)
-        self._zoom_window = (abscissa_from_index, 0.0, abscissa_to_index, 1.0)
+        self._zoom_window = (0, 0.0, 1, 1.0)
         # steps
         self._step_information = step_information
         self._selected_steps: set[int] = set(range(self._step_information.length))
@@ -90,17 +90,8 @@ class Chart:
         self.plot_series(self.expressions)
 
     def render(self, abscissa_label: str, abscissa_scale: str, initial_expressions: set[Expression]):
-        # abscissa data for the first step
-        first_step_slice = self._step_information.abscissa_indices[0]
-        # local zoom bounds for the first step
-        first_from_index, first_to_index = self._get_step_zoom_bounds(0)
-        # abscissa data for the first step and local zoom range
-        abscissa_data = self._abscissa.data[first_step_slice.start + first_from_index:first_step_slice.start + first_to_index]
-        # x0 and x1 (from first step)
-        abscissa_left_value = float(abscissa_data[0])
-        abscissa_right_value = float(abscissa_data[-1])
         # initialize chart component
-        self._component.initialize(abscissa_label, self._abscissa.unit, abscissa_scale, abscissa_left_value, abscissa_right_value)
+        self._component.initialize(abscissa_label, self._abscissa.unit, abscissa_scale, self._step_information.abscissa_from_value, self._step_information.abscissa_to_value)
         # render all expressions as series
         self.plot_series(initial_expressions)
         # auto range axes based on the added series
@@ -118,13 +109,13 @@ class Chart:
         for label, (expression, ordinate_series) in self._series.items():
             # check expression should be removed
             if expression not in expressions:
-                # log information
-                logger.debug("Removing series for expression '%s' from chart", expression.name)
                 # enqueue series for removal
                 for ordinate_variant, (axis, rendered_series, _, _, _) in ordinate_series.items():
                     # release axis if no longer in use
                     if self._release_y_axis(axis):
                         axes_to_remove.append(axis)
+                    # log information
+                    logger.debug("Removing series for expression [%s] from chart, steps: %s", ordinate_variant.name, list(rendered_series.keys()))
                     # append to list for later removal from chart
                     series_to_remove.append([ordinate_variant.name, list(rendered_series.values())])
                 # remove from tracked series so we don't try to update it later
@@ -144,16 +135,12 @@ class Chart:
                 for step in list(rendered_series.keys()):
                     # check step should be removed
                     if step not in self._selected_steps:
+                        # log information
+                        logger.debug("Removing series for expression [%s] from chart, step: %d", ordinate_variant.name, step)
                         # append to list for later removal from chart
                         series_to_remove.append([None, [rendered_series[step]]])
                         # remove from dictionary so we don't try to update it later
                         del rendered_series[step]
-                # check we need to generate a color for this expression
-                if color is None:
-                    # assign next color in palette
-                    color = _SERIES_COLOR_PALETTE[self._next_color_index % len(_SERIES_COLOR_PALETTE)]
-                    # update index
-                    self._next_color_index += 1
                 # process axis as needed
                 if y_axis is None:
                     # find y axis for measurement type
@@ -163,6 +150,12 @@ class Chart:
                         logger.warning(f"Cannot add series '{ordinate_variant.name}' of measurement type {ordinate_variant.unit} to chart — maximum number of Y axes reached")
                         # exit loop
                         break
+                # check we need to generate a color for this expression
+                if color is None:
+                    # assign next color in palette
+                    color = _SERIES_COLOR_PALETTE[self._next_color_index % len(_SERIES_COLOR_PALETTE)]
+                    # update index
+                    self._next_color_index += 1
                 # ordinate series to render
                 ordinate_series_to_render: list[QLineSeries] = []
                 # loop steps
@@ -172,12 +165,17 @@ class Chart:
                         continue
                     # step slice
                     step_slice = self._step_information.abscissa_indices[step]
-                    # local zoom bounds for this step
-                    zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
-                    # apply zoom window to abscissa
-                    abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
-                    # ordinate variant values for this step (as contiguous array in memory), apply zoom window
-                    ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
+
+                    # # local zoom bounds for this step
+                    # zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
+                    # # apply zoom window to abscissa
+                    # abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
+                    # # ordinate variant values for this step (as contiguous array in memory), apply zoom window
+                    # ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
+
+                    abscissa_values = self._abscissa.data[step_slice]
+                    ordinate_values = ordinate_variant.data[step_slice]
+
                     # skip inconsistent slices to protect decimation input contracts
                     if abscissa_values.size == 0 or ordinate_values.size == 0 or abscissa_values.size != ordinate_values.size:
                         continue
@@ -194,6 +192,8 @@ class Chart:
                     # check all values were non-finite after filtering
                     if x_np.size == 0 or y_np.size == 0:
                         continue
+                    # log information
+                    logger.debug("Adding series for expression [%s], step: %d, original size: %d, decimated size: %d", ordinate_variant.name, step, abscissa_values.size, x_np.size)
                     # create series and hand buffers directly to Qt — no Python loop
                     series = QLineSeries()
                     series.setColor(color)
@@ -249,63 +249,65 @@ class Chart:
             y_axis.setRange(y_min - delta, y_max + delta)
 
     def update_zoom_window(self, abscissa_from_index: int, abscissa_to_index: int, y_top_ratio: float | None, y_bottom_ratio: float | None):
-        # vertical changes flag
-        vertical_changed = False
-        # check vertical zoom ratios were provided
-        if y_top_ratio is not None and y_bottom_ratio is not None:
-            # current zoom window
-            _, current_y_top_ratio, _, current_y_bottom_ratio = self._zoom_window
-            # calculate new ratios based on the position of the mouse event within the chart panel and the current zoom window
-            y_top_ratio = current_y_top_ratio + y_top_ratio * (current_y_bottom_ratio - current_y_top_ratio)
-            y_bottom_ratio = current_y_top_ratio + y_bottom_ratio * (current_y_bottom_ratio - current_y_top_ratio)
-            # update zoom window
-            self._zoom_window = (self._zoom_window[0], y_top_ratio, self._zoom_window[2], y_bottom_ratio)
-            # update flag
-            vertical_changed = True
-        # check horizontal zoom indexes were provided
-        if abscissa_from_index >= 0 and abscissa_to_index >= 0:
-            # update zoom window
-            self._zoom_window = (abscissa_from_index, self._zoom_window[1], abscissa_to_index, self._zoom_window[3])
-            # process all series to apply the new zoom window, full redraw if horizontal zoom changed
-            self._redraw_all_series()
-            # auto range axes based on the new zoom window
-            return self.auto_range() if vertical_changed else None
-        # partial redraw sufficient when only vertical zoom changed
-        _, y_top_ratio, _, y_bottom_ratio = self._zoom_window
-        # update axis ranges based on collected min and max values for each variable type
-        for y_axis, (y_min, y_max) in self._axis_ranges.items():
-            # range
-            scale = y_max - y_min
-            # set y axis range
-            y_axis.setRange(y_min + y_top_ratio * scale, y_min + y_bottom_ratio * scale)
+        # # vertical changes flag
+        # vertical_changed = False
+        # # check vertical zoom ratios were provided
+        # if y_top_ratio is not None and y_bottom_ratio is not None:
+        #     # current zoom window
+        #     _, current_y_top_ratio, _, current_y_bottom_ratio = self._zoom_window
+        #     # calculate new ratios based on the position of the mouse event within the chart panel and the current zoom window
+        #     y_top_ratio = current_y_top_ratio + y_top_ratio * (current_y_bottom_ratio - current_y_top_ratio)
+        #     y_bottom_ratio = current_y_top_ratio + y_bottom_ratio * (current_y_bottom_ratio - current_y_top_ratio)
+        #     # update zoom window
+        #     self._zoom_window = (self._zoom_window[0], y_top_ratio, self._zoom_window[2], y_bottom_ratio)
+        #     # update flag
+        #     vertical_changed = True
+        # # check horizontal zoom indexes were provided
+        # if abscissa_from_index >= 0 and abscissa_to_index >= 0:
+        #     # update zoom window
+        #     self._zoom_window = (abscissa_from_index, self._zoom_window[1], abscissa_to_index, self._zoom_window[3])
+        #     # process all series to apply the new zoom window, full redraw if horizontal zoom changed
+        #     self._redraw_all_series()
+        #     # auto range axes based on the new zoom window
+        #     return self.auto_range() if vertical_changed else None
+        # # partial redraw sufficient when only vertical zoom changed
+        # _, y_top_ratio, _, y_bottom_ratio = self._zoom_window
+        # # update axis ranges based on collected min and max values for each variable type
+        # for y_axis, (y_min, y_max) in self._axis_ranges.items():
+        #     # range
+        #     scale = y_max - y_min
+        #     # set y axis range
+        #     y_axis.setRange(y_min + y_top_ratio * scale, y_min + y_bottom_ratio * scale)
+        ...
 
     def reset_zoom_window(self, abscissa_from_index: int, abscissa_to_index: int, y_top_ratio: float | None, y_bottom_ratio: float | None):
-        # vertical changes flag
-        vertical_changed = False
-        # check vertical zoom ratios were provided
-        if y_top_ratio is not None and y_bottom_ratio is not None:
-            # update flag
-            vertical_changed = y_top_ratio != self._zoom_window[1] or y_bottom_ratio != self._zoom_window[3]
-            # update zoom window
-            self._zoom_window = (self._zoom_window[0], y_top_ratio, self._zoom_window[2], y_bottom_ratio)
-        # check horizontal zoom indexes were provided
-        if abscissa_from_index >= 0 and abscissa_to_index >= 0:
-            # update zoom window
-            self._zoom_window = (abscissa_from_index, self._zoom_window[1], abscissa_to_index, self._zoom_window[3])
-            # process all series to apply the new zoom window, full redraw if horizontal zoom changed
-            self._redraw_all_series()
-            # auto range axes if vertical zoom also changed, otherwise just update axis ranges based on the new zoom window
-            return self.auto_range() if vertical_changed else None
-        # check if vertical zoom changed, if not we can skip the redraw and just update the axis ranges based on the new zoom window
-        if vertical_changed:
-            # log information
-            logger.debug("Vertical zoom changed, updating axis ranges based on new zoom window")
-            # partial redraw sufficient when only vertical zoom changed
-            _, y_top_ratio, _, y_bottom_ratio = self._zoom_window
-            # update axis ranges based on collected min and max values for each variable type
-            for y_axis, (y_min, y_max) in self._axis_ranges.items():
-                # set y axis range
-                y_axis.setRange(y_min, y_max)
+        # # vertical changes flag
+        # vertical_changed = False
+        # # check vertical zoom ratios were provided
+        # if y_top_ratio is not None and y_bottom_ratio is not None:
+        #     # update flag
+        #     vertical_changed = y_top_ratio != self._zoom_window[1] or y_bottom_ratio != self._zoom_window[3]
+        #     # update zoom window
+        #     self._zoom_window = (self._zoom_window[0], y_top_ratio, self._zoom_window[2], y_bottom_ratio)
+        # # check horizontal zoom indexes were provided
+        # if abscissa_from_index >= 0 and abscissa_to_index >= 0:
+        #     # update zoom window
+        #     self._zoom_window = (abscissa_from_index, self._zoom_window[1], abscissa_to_index, self._zoom_window[3])
+        #     # process all series to apply the new zoom window, full redraw if horizontal zoom changed
+        #     self._redraw_all_series()
+        #     # auto range axes if vertical zoom also changed, otherwise just update axis ranges based on the new zoom window
+        #     return self.auto_range() if vertical_changed else None
+        # # check if vertical zoom changed, if not we can skip the redraw and just update the axis ranges based on the new zoom window
+        # if vertical_changed:
+        #     # log information
+        #     logger.debug("Vertical zoom changed, updating axis ranges based on new zoom window")
+        #     # partial redraw sufficient when only vertical zoom changed
+        #     _, y_top_ratio, _, y_bottom_ratio = self._zoom_window
+        #     # update axis ranges based on collected min and max values for each variable type
+        #     for y_axis, (y_min, y_max) in self._axis_ranges.items():
+        #         # set y axis range
+        #         y_axis.setRange(y_min, y_max)
+        ...
 
     def clear(self):
         # Qt enqueues the visual removal of series asynchronously. Python owns the QLineSeries, so we must NOT let Python GC them until Qt has finished processing the removal queue.
@@ -478,75 +480,76 @@ class Chart:
         return []
 
     def _redraw_all_series(self):
-        # x0 and x1
-        abscissa_left_value: float | None = None
-        abscissa_right_value: float | None = None
-        try:
-            # loop existing series
-            for _, (_, ordinate_series) in self._series.items():
-                # loop series data (actual data visible in chart)
-                for ordinate_variant, (y_axis, rendered_series, _, _, color) in ordinate_series.items():
-                    # min and max value recalculation for the new zoom window
-                    min_value = float("inf")
-                    max_value = float("-inf")
-                    # loop steps
-                    for step, series in rendered_series.items():
-                        # step slice
-                        step_slice = self._step_information.abscissa_indices[step]
-                        # local zoom bounds for this step
-                        zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
-                        # abscissa values
-                        abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
-                        # ordinate variant values for this step & zoom window
-                        ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
-                        # skip inconsistent slices to protect decimation input contracts
-                        if abscissa_values.size == 0 or ordinate_values.size == 0 or abscissa_values.size != ordinate_values.size:
-                            continue
-                        # decimate x and y jointly so every plotted (x, y) pair maps to the same original sample
-                        x_np, y_np = decimate_xy(abscissa_values, ordinate_values, self._decimate_target, _DECIMATION_ALGORITHM)
-                        # remove Inf values
-                        inf_mask = np.isinf(y_np)
-                        if inf_mask.any():
-                            # mask for finite values
-                            keep_mask = ~inf_mask
-                            # update x and y with finite values only
-                            x_np = x_np[keep_mask]
-                            y_np = y_np[keep_mask]
-                        # check all values were non-finite after filtering
-                        if x_np.size == 0 or y_np.size == 0:
-                            continue
-                        # update series with decimated data
-                        series.replaceNp(x_np, y_np)
-                        # update min and max values
-                        min_value = min(min_value, float(np.min(y_np)))
-                        max_value = max(max_value, float(np.max(y_np)))
-                        # update x axis left and right values based on the new zoom window
-                        if abscissa_left_value is None or abscissa_right_value is None:
-                            # initialize values for the first series processed
-                            abscissa_left_value = float(abscissa_values[0])
-                            abscissa_right_value = float(abscissa_values[-1])
-                        elif abscissa_left_value < abscissa_right_value:
-                            # ascending abscissa, update left and right values as needed
-                            abscissa_left_value = min(abscissa_left_value, float(abscissa_values[0]))
-                            abscissa_right_value = max(abscissa_right_value, float(abscissa_values[-1]))
-                        else:
-                            # descending abscissa, update left and right values as needed
-                            abscissa_left_value = max(abscissa_left_value, float(abscissa_values[0]))
-                            abscissa_right_value = min(abscissa_right_value, float(abscissa_values[-1]))
-                    # calculate scale for Y axis
-                    scale = max(abs(max_value), abs(min_value))
-                    # Y axis range
-                    y_range = max_value - min_value
-                    if y_range <= scale * 1e-9:
-                        y_range = abs(max_value) * 0.01 if scale != 0 else 1.0
-                    # protect against very small ranges
-                    delta = max(0.01 * y_range, 1e-3)
-                    # update dictionary entry
-                    ordinate_series[ordinate_variant] = (y_axis, rendered_series, min_value - delta, max_value + delta, color)
-        finally:
-            # resize abscissa axis
-            if abscissa_left_value is not None and abscissa_right_value is not None:
-                self._component.resizeAbscissa(abscissa_left_value, abscissa_right_value)
+        # # x0 and x1
+        # abscissa_left_value: float | None = None
+        # abscissa_right_value: float | None = None
+        # try:
+        #     # loop existing series
+        #     for _, (_, ordinate_series) in self._series.items():
+        #         # loop series data (actual data visible in chart)
+        #         for ordinate_variant, (y_axis, rendered_series, _, _, color) in ordinate_series.items():
+        #             # min and max value recalculation for the new zoom window
+        #             min_value = float("inf")
+        #             max_value = float("-inf")
+        #             # loop steps
+        #             for step, series in rendered_series.items():
+        #                 # step slice
+        #                 step_slice = self._step_information.abscissa_indices[step]
+        #                 # local zoom bounds for this step
+        #                 zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
+        #                 # abscissa values
+        #                 abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
+        #                 # ordinate variant values for this step & zoom window
+        #                 ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
+        #                 # skip inconsistent slices to protect decimation input contracts
+        #                 if abscissa_values.size == 0 or ordinate_values.size == 0 or abscissa_values.size != ordinate_values.size:
+        #                     continue
+        #                 # decimate x and y jointly so every plotted (x, y) pair maps to the same original sample
+        #                 x_np, y_np = decimate_xy(abscissa_values, ordinate_values, self._decimate_target, _DECIMATION_ALGORITHM)
+        #                 # remove Inf values
+        #                 inf_mask = np.isinf(y_np)
+        #                 if inf_mask.any():
+        #                     # mask for finite values
+        #                     keep_mask = ~inf_mask
+        #                     # update x and y with finite values only
+        #                     x_np = x_np[keep_mask]
+        #                     y_np = y_np[keep_mask]
+        #                 # check all values were non-finite after filtering
+        #                 if x_np.size == 0 or y_np.size == 0:
+        #                     continue
+        #                 # update series with decimated data
+        #                 series.replaceNp(x_np, y_np)
+        #                 # update min and max values
+        #                 min_value = min(min_value, float(np.min(y_np)))
+        #                 max_value = max(max_value, float(np.max(y_np)))
+        #                 # update x axis left and right values based on the new zoom window
+        #                 if abscissa_left_value is None or abscissa_right_value is None:
+        #                     # initialize values for the first series processed
+        #                     abscissa_left_value = float(abscissa_values[0])
+        #                     abscissa_right_value = float(abscissa_values[-1])
+        #                 elif abscissa_left_value < abscissa_right_value:
+        #                     # ascending abscissa, update left and right values as needed
+        #                     abscissa_left_value = min(abscissa_left_value, float(abscissa_values[0]))
+        #                     abscissa_right_value = max(abscissa_right_value, float(abscissa_values[-1]))
+        #                 else:
+        #                     # descending abscissa, update left and right values as needed
+        #                     abscissa_left_value = max(abscissa_left_value, float(abscissa_values[0]))
+        #                     abscissa_right_value = min(abscissa_right_value, float(abscissa_values[-1]))
+        #             # calculate scale for Y axis
+        #             scale = max(abs(max_value), abs(min_value))
+        #             # Y axis range
+        #             y_range = max_value - min_value
+        #             if y_range <= scale * 1e-9:
+        #                 y_range = abs(max_value) * 0.01 if scale != 0 else 1.0
+        #             # protect against very small ranges
+        #             delta = max(0.01 * y_range, 1e-3)
+        #             # update dictionary entry
+        #             ordinate_series[ordinate_variant] = (y_axis, rendered_series, min_value - delta, max_value + delta, color)
+        # finally:
+        #     # resize abscissa axis
+        #     if abscissa_left_value is not None and abscissa_right_value is not None:
+        #         self._component.resizeAbscissa(abscissa_left_value, abscissa_right_value)
+        ...
 
     def _get_y_axis(self, unit: str) -> QAbstractAxis | None:
         # existing axis for measurement type

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -44,7 +44,7 @@ def _binary_search(data: np.ndarray, value: float, ascending: bool, side: int) -
         while lo < hi:
             # middle index
             middle = (lo + hi) // 2
-            # compare middle value with target value            
+            # compare middle value with target value
             if (side == 1 and data[middle] < value) or (side == -1 and data[middle] <= value):
                 # move lo up
                 lo = middle + 1
@@ -57,7 +57,7 @@ def _binary_search(data: np.ndarray, value: float, ascending: bool, side: int) -
     while lo < hi:
         # middle index
         middle = (lo + hi) // 2
-        # compare middle value with target value            
+        # compare middle value with target value
         if (side == 1 and data[middle] > value) or (side == -1 and data[middle] >= value):
             # move lo up
             lo = middle + 1
@@ -124,6 +124,10 @@ class Chart:
     @property
     def selected_steps(self) -> set[int]:
         return self._selected_steps
+
+    @property
+    def zoom_window(self) -> tuple[float | None, float | None, float | None, float | None]:
+        return self._zoom_window
 
     @selected_steps.setter
     def selected_steps(self, selected_steps: set[int]) -> None:
@@ -381,7 +385,7 @@ class Chart:
         if not self._series:
             return []
         # ascending or descending abscissa
-        ascending = self._step_information.abscissa_ascending        
+        ascending = self._step_information.abscissa_ascending
         # collect one (name, unit, value) tuple per plotted variant (magnitude/phase counted separately)
         result: list[tuple[str, str, list[float]]] = []
         # loop series
@@ -405,13 +409,13 @@ class Chart:
                 result.append((ordinate_variant.name, ordinate_variant.unit, values))
         # exit
         return result
-    
+
     def _ratio_to_abscissa_value(self, x_ratio: float) -> float:
         # make sure ratio is between 0 and 1
         percentage = max(0.0, min(1.0, x_ratio))
         # convert to abscissa value
         return self._step_information.abscissa_left_value + percentage * (self._step_information.abscissa_right_value - self._step_information.abscissa_left_value)
-    
+
     def abscissa_value_at_cursor(self, cursor: float) -> float:
         # make sure cursor is between 0 and 1
         percentage = max(0.0, min(1.0, cursor))

--- a/viewer/chart.py
+++ b/viewer/chart.py
@@ -34,6 +34,52 @@ _SERIES_COLOR_PALETTE = [
 ]
 
 
+def _binary_search(data: np.ndarray, value: float, ascending: bool, side: int) -> int:
+    """ O(log n) binary search that repects sort order without array copying or view creation. side == 1 for left bound, -1 for right bound"""
+    # initialize lo and hi
+    lo, hi = 0, len(data)
+    # check data is ascending
+    if ascending:
+        # loop
+        while lo < hi:
+            # middle index
+            middle = (lo + hi) // 2
+            # compare middle value with target value            
+            if (side == 1 and data[middle] < value) or (side == -1 and data[middle] <= value):
+                # move lo up
+                lo = middle + 1
+            else:
+                # move hi down
+                hi = middle
+        # exit
+        return lo
+    # data is descending, loop
+    while lo < hi:
+        # middle index
+        middle = (lo + hi) // 2
+        # compare middle value with target value            
+        if (side == 1 and data[middle] > value) or (side == -1 and data[middle] >= value):
+            # move lo up
+            lo = middle + 1
+        else:
+            # move hi down
+            hi = middle
+    # exit
+    return lo
+
+
+def _find_abscissa_index_for_value(data: np.ndarray, value: float, ascending: bool) -> int:
+    # find insertion point using binary search
+    index = _binary_search(data, value, ascending, side=1)
+    # clamp to valid range
+    index = min(index, len(data) - 1)
+    # check if the previous index is closer to the target value
+    if index > 0 and abs(data[index - 1] - value) <= abs(data[index] - value):
+        return index - 1
+    # otherwise return the found index
+    return index
+
+
 class Chart:
 
     def __init__(self, component: QQuickItem, char_type: str, expression_manager: ExpressionManager, abscissa: Expression, step_information: StepInformation, decimate_target: int):
@@ -45,8 +91,8 @@ class Chart:
         self._expression_manager = expression_manager
         # store variables
         self._abscissa = abscissa
-        # current zoom window (x: in abscissa index, y: in ordinate percentages)
-        self._zoom_window = (0, 0.0, 1, 1.0)
+        # current zoom window (x: in abscissa percentages, y: in ordinate percentages)
+        self._zoom_window = (None, None, None, None)
         # steps
         self._step_information = step_information
         self._selected_steps: set[int] = set(range(self._step_information.length))
@@ -91,7 +137,7 @@ class Chart:
 
     def render(self, abscissa_label: str, abscissa_scale: str, initial_expressions: set[Expression]):
         # initialize chart component
-        self._component.initialize(abscissa_label, self._abscissa.unit, abscissa_scale, self._step_information.abscissa_from_value, self._step_information.abscissa_to_value)
+        self._component.initialize(abscissa_label, self._abscissa.unit, abscissa_scale, self._step_information.abscissa_left_value, self._step_information.abscissa_right_value)
         # render all expressions as series
         self.plot_series(initial_expressions)
         # auto range axes based on the added series
@@ -123,6 +169,11 @@ class Chart:
         # update dictionary outside loop
         for label in labels_to_remove:
             del self._series[label]
+        # current zoom window in abscissa values, None if not set
+        x_left_ratio, _, x_right_ratio, _ = self._zoom_window
+        # x0 and x1
+        abscissa_left_value = self.ratio_to_abscissa_value(x_left_ratio) if x_left_ratio is not None else self._step_information.abscissa_left_value
+        abscissa_right_value = self.ratio_to_abscissa_value(x_right_ratio) if x_right_ratio is not None else self._step_information.abscissa_right_value
         # loop expressions that should be plotted
         for ordinate in expressions:
             # lookup ordinate in series
@@ -165,22 +216,22 @@ class Chart:
                         continue
                     # step slice
                     step_slice = self._step_information.abscissa_indices[step]
-
-                    # # local zoom bounds for this step
-                    # zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
-                    # # apply zoom window to abscissa
-                    # abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
-                    # # ordinate variant values for this step (as contiguous array in memory), apply zoom window
-                    # ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
-
+                    # step abscissa & ordinate values
                     abscissa_values = self._abscissa.data[step_slice]
-                    ordinate_values = ordinate_variant.data[step_slice]
-
+                    ordinate_values_at_abscissa_value = ordinate_variant.data[step_slice]
+                    # check we have a zoom window to apply
+                    if x_left_ratio is not None and x_right_ratio is not None:
+                        # find indexes for the new zoom window
+                        indexes = self._find_abscissa_indexes(abscissa_values, abscissa_left_value, abscissa_right_value)
+                        # abscissa values
+                        abscissa_values = abscissa_values[indexes]
+                        # ordinate variant values for this step & zoom window
+                        ordinate_values_at_abscissa_value = ordinate_values_at_abscissa_value[indexes]
                     # skip inconsistent slices to protect decimation input contracts
-                    if abscissa_values.size == 0 or ordinate_values.size == 0 or abscissa_values.size != ordinate_values.size:
+                    if abscissa_values.size == 0:
                         continue
                     # decimate x and y jointly so every plotted (x, y) pair maps to the same original sample
-                    x_np, y_np = decimate_xy(abscissa_values, ordinate_values, self._decimate_target, _DECIMATION_ALGORITHM)
+                    x_np, y_np = decimate_xy(abscissa_values, ordinate_values_at_abscissa_value, self._decimate_target, _DECIMATION_ALGORITHM)
                     # remove Inf values
                     inf_mask = np.isinf(y_np)
                     if inf_mask.any():
@@ -248,66 +299,60 @@ class Chart:
             # set y axis range
             y_axis.setRange(y_min - delta, y_max + delta)
 
-    def update_zoom_window(self, abscissa_from_index: int, abscissa_to_index: int, y_top_ratio: float | None, y_bottom_ratio: float | None):
-        # # vertical changes flag
-        # vertical_changed = False
-        # # check vertical zoom ratios were provided
-        # if y_top_ratio is not None and y_bottom_ratio is not None:
-        #     # current zoom window
-        #     _, current_y_top_ratio, _, current_y_bottom_ratio = self._zoom_window
-        #     # calculate new ratios based on the position of the mouse event within the chart panel and the current zoom window
-        #     y_top_ratio = current_y_top_ratio + y_top_ratio * (current_y_bottom_ratio - current_y_top_ratio)
-        #     y_bottom_ratio = current_y_top_ratio + y_bottom_ratio * (current_y_bottom_ratio - current_y_top_ratio)
-        #     # update zoom window
-        #     self._zoom_window = (self._zoom_window[0], y_top_ratio, self._zoom_window[2], y_bottom_ratio)
-        #     # update flag
-        #     vertical_changed = True
-        # # check horizontal zoom indexes were provided
-        # if abscissa_from_index >= 0 and abscissa_to_index >= 0:
-        #     # update zoom window
-        #     self._zoom_window = (abscissa_from_index, self._zoom_window[1], abscissa_to_index, self._zoom_window[3])
-        #     # process all series to apply the new zoom window, full redraw if horizontal zoom changed
-        #     self._redraw_all_series()
-        #     # auto range axes based on the new zoom window
-        #     return self.auto_range() if vertical_changed else None
-        # # partial redraw sufficient when only vertical zoom changed
-        # _, y_top_ratio, _, y_bottom_ratio = self._zoom_window
-        # # update axis ranges based on collected min and max values for each variable type
-        # for y_axis, (y_min, y_max) in self._axis_ranges.items():
-        #     # range
-        #     scale = y_max - y_min
-        #     # set y axis range
-        #     y_axis.setRange(y_min + y_top_ratio * scale, y_min + y_bottom_ratio * scale)
-        ...
+    def update_zoom_window(self, x_left_ratio: float | None, x_right_ratio: float | None, y_top_ratio: float | None, y_bottom_ratio: float | None):
+        # check horizontal zoom ratios were provided
+        if x_left_ratio is not None and x_right_ratio is not None:
+            # current zoom window
+            current_x_left_ratio, _, current_x_right_ratio, _ = self._zoom_window
+            # calculate new ratios based on the position of the mouse within the chart panel and the current zoom window
+            x_left_ratio = (current_x_left_ratio or 0.0) + x_left_ratio * ((current_x_right_ratio or 1.0) - (current_x_left_ratio or 0.0))
+            x_right_ratio = (current_x_left_ratio or 0.0) + x_right_ratio * ((current_x_right_ratio or 1.0) - (current_x_left_ratio or 0.0))
+            # update zoom window
+            self._zoom_window = (x_left_ratio, self._zoom_window[1], x_right_ratio, self._zoom_window[3])
+            # process all series to apply the new zoom window, full redraw if horizontal zoom changed
+            self._redraw_all_series()
+        # check vertical zoom ratios were provided
+        if y_top_ratio is not None and y_bottom_ratio is not None:
+            # current zoom window
+            _, current_y_top_ratio, _, current_y_bottom_ratio = self._zoom_window
+            # calculate new ratios based on the position of the mouse within the chart panel and the current zoom window
+            y_top_ratio = (current_y_top_ratio or 0.0) + y_top_ratio * ((current_y_bottom_ratio or 1.0) - (current_y_top_ratio or 0.0))
+            y_bottom_ratio = (current_y_top_ratio or 0.0) + y_bottom_ratio * ((current_y_bottom_ratio or 1.0) - (current_y_top_ratio or 0.0))
+            # update zoom window
+            self._zoom_window = (self._zoom_window[0], y_top_ratio, self._zoom_window[2], y_bottom_ratio)
+            # update axis ranges based on collected min and max values for each variable type
+            for y_axis, (y_min, y_max) in self._axis_ranges.items():
+                # range (from data)
+                y_range = y_max - y_min
+                # delta
+                delta = 0.03 * y_range
+                # actual axis min/max values (see auto_range)
+                visual_y_min = y_min - delta
+                visual_y_max = y_max + delta
+                # calculate visual axis range
+                visual_y_range = visual_y_max - visual_y_min
+                # set y axis range
+                y_axis.setRange(visual_y_min + y_top_ratio * visual_y_range, visual_y_min + y_bottom_ratio * visual_y_range)
 
-    def reset_zoom_window(self, abscissa_from_index: int, abscissa_to_index: int, y_top_ratio: float | None, y_bottom_ratio: float | None):
-        # # vertical changes flag
-        # vertical_changed = False
-        # # check vertical zoom ratios were provided
-        # if y_top_ratio is not None and y_bottom_ratio is not None:
-        #     # update flag
-        #     vertical_changed = y_top_ratio != self._zoom_window[1] or y_bottom_ratio != self._zoom_window[3]
-        #     # update zoom window
-        #     self._zoom_window = (self._zoom_window[0], y_top_ratio, self._zoom_window[2], y_bottom_ratio)
-        # # check horizontal zoom indexes were provided
-        # if abscissa_from_index >= 0 and abscissa_to_index >= 0:
-        #     # update zoom window
-        #     self._zoom_window = (abscissa_from_index, self._zoom_window[1], abscissa_to_index, self._zoom_window[3])
-        #     # process all series to apply the new zoom window, full redraw if horizontal zoom changed
-        #     self._redraw_all_series()
-        #     # auto range axes if vertical zoom also changed, otherwise just update axis ranges based on the new zoom window
-        #     return self.auto_range() if vertical_changed else None
-        # # check if vertical zoom changed, if not we can skip the redraw and just update the axis ranges based on the new zoom window
-        # if vertical_changed:
-        #     # log information
-        #     logger.debug("Vertical zoom changed, updating axis ranges based on new zoom window")
-        #     # partial redraw sufficient when only vertical zoom changed
-        #     _, y_top_ratio, _, y_bottom_ratio = self._zoom_window
-        #     # update axis ranges based on collected min and max values for each variable type
-        #     for y_axis, (y_min, y_max) in self._axis_ranges.items():
-        #         # set y axis range
-        #         y_axis.setRange(y_min, y_max)
-        ...
+    def reset_zoom_window(self, horizontal: bool, vertical: bool):
+        # check horizontal reset
+        if horizontal:
+            # update zoom window
+            self._zoom_window = (None, self._zoom_window[1], None, self._zoom_window[3])
+            # process all series to apply the new zoom window, full redraw if horizontal zoom changed
+            self._redraw_all_series()
+        # check vertical reset
+        if vertical:
+            # update zoom window
+            self._zoom_window = (self._zoom_window[0], None, self._zoom_window[2], None)
+            # update axis ranges based on collected min and max values for each variable type
+            for y_axis, (y_min, y_max) in self._axis_ranges.items():
+                # range
+                y_range = y_max - y_min
+                # delta
+                delta = 0.03 * y_range
+                # set y axis range
+                y_axis.setRange(y_min - delta, y_max + delta)
 
     def clear(self):
         # Qt enqueues the visual removal of series asynchronously. Python owns the QLineSeries, so we must NOT let Python GC them until Qt has finished processing the removal queue.
@@ -320,7 +365,7 @@ class Chart:
         # reset color index for new series
         self._next_color_index = 0
         # reset zoom window (vertical axes only, keep horizontal range)
-        self._zoom_window = (self._zoom_window[0], 0.0, self._zoom_window[2], 1.0)
+        self._zoom_window = (self._zoom_window[0], None, self._zoom_window[2], None)
         # enqueue Qt-side removal
         self._component.removeAllSeries()
         # remove axis references
@@ -331,23 +376,12 @@ class Chart:
         # release stash after Qt finishes its async processing
         QTimer.singleShot(1000, lambda: (old_series.clear(), old_y_axes.clear()))
 
-    def sample_at(self, x_ratio: float) -> list[tuple[str, str, list[float]]]:
+    def ordinate_values_at_abscissa_value(self, x_value: float) -> list[tuple[str, str, list[float]]]:
         # check series are plotted
         if not self._series:
             return []
-        # clamped horizontal ratio in visible window
-        x_ratio = max(0.0, min(1.0, x_ratio))
-        # current horizontal zoom bounds
-        from_index, to_index = self.zoom_abscissa_bounds()
-        # reference step for x mapping, using the first selected step when available
-        reference_step = min(self._selected_steps) if self._selected_steps else 0
-        # reference step slice
-        reference_slice = self._step_information.abscissa_indices[reference_step]
-        # visible abscissa window for the reference step
-        window = self._abscissa.data[reference_slice.start + from_index:reference_slice.start + to_index]
-        # check visible window is empty
-        if window.size == 0:
-            return []
+        # ascending or descending abscissa
+        ascending = self._step_information.abscissa_ascending        
         # collect one (name, unit, value) tuple per plotted variant (magnitude/phase counted separately)
         result: list[tuple[str, str, list[float]]] = []
         # loop series
@@ -356,107 +390,39 @@ class Chart:
             for ordinate_variant, (_, rendered_series, _, _, _) in ordinate_series.items():
                 # values (per step)
                 values: list[float] = []
-                # # step and series for this step
-                # for step, _ in rendered_series.items():
-                #     # step slice
-                #     step_slice = self._step_information.abscissa_indices[step]
-                #     # fallback to raw value at nearest original sample index (this is not correct, idx is for decimated points)
-                #     values.append(float(ordinate_variant.data[step_slice][idx]))
+                # step and series for this step
+                for step, _ in rendered_series.items():
+                    # step slice
+                    step_slice = self._step_information.abscissa_indices[step]
+                    # abscissa & ordinate values for this step
+                    abscissa_data = self._abscissa.data[step_slice]
+                    ordinate_data = ordinate_variant.data[step_slice]
+                    # find abscissa index for value
+                    index = _find_abscissa_index_for_value(abscissa_data, x_value, ascending)
+                    # append ordinate value at this abscissa value
+                    values.append(float(ordinate_data[index]))
                 # append to result (name, unit, value)
                 result.append((ordinate_variant.name, ordinate_variant.unit, values))
         # exit
         return result
+    
+    def ratio_to_abscissa_value(self, x_ratio: float) -> float:
+        # make sure ratio is between 0 and 1
+        percentage = max(0.0, min(1.0, x_ratio))
+        # convert to abscissa value
+        return self._step_information.abscissa_left_value + percentage * (self._step_information.abscissa_right_value - self._step_information.abscissa_left_value)
 
-    def zoom_abscissa_bounds(self) -> tuple[int, int]:
-        # current abscissa bounds in sample indexes
-        return self._zoom_window[0], self._zoom_window[2]
-
-    def _get_step_zoom_bounds(self, step: int) -> tuple[int, int]:
-        # step length for this step
-        step_length = self._step_information.step_length(step)
-        # keep at least two points when possible for stable zoom and FFT windows
-        if step_length <= 1:
-            return 0, step_length
-        # clamp zoom start to step bounds
-        from_index = max(0, min(self._zoom_window[0], step_length - 2))
-        # clamp zoom end to step bounds and enforce a minimum window size of two points
-        to_index = max(from_index + 2, min(self._zoom_window[2], step_length))
-        # return local bounds
-        return from_index, to_index
-
-    def sample_index_at_ratio(self, x_ratio: float) -> int:
-        # x zoom window indexes
-        from_index, to_index = self.zoom_abscissa_bounds()
-        # reference step for x mapping, using the first selected step when available
-        reference_step = min(self._selected_steps) if self._selected_steps else 0
-        # clamp bounds to the reference step
-        from_index, to_index = self._get_step_zoom_bounds(reference_step)
-        # reference slice
-        reference_slice = self._step_information.abscissa_indices[reference_step]
-        # clamp ratio to visible horizontal span
-        x_ratio = max(0.0, min(1.0, x_ratio))
-        # window length
-        window_len = to_index - from_index
-        # check visible window has a single point
-        if window_len <= 1:
-            # return only sample index in window
-            return from_index
-        # visible abscissa window which can be non-uniformly spaced
-        window = self._abscissa.data[reference_slice.start + from_index:reference_slice.start + to_index]
-        # target x value on the visible axis for the given cursor ratio
-        target = float(window[0] + x_ratio * (window[-1] - window[0]))
-        # check ascending abscissa ordering
-        if window[0] <= window[-1]:
-            # insertion index in visible window
-            insert_at = int(np.searchsorted(window, target, side="left"))
-            # check target is left of the first visible sample
-            if insert_at <= 0:
-                # clamp to left bound
-                return from_index
-            # check target is right of the last visible sample
-            if insert_at >= window_len:
-                # clamp to right bound
-                return to_index - 1
-            # nearest neighbors around insertion point
-            left_idx = insert_at - 1
-            right_idx = insert_at
-            # distance to left neighbor
-            left_dist = abs(float(window[left_idx]) - target)
-            # distance to right neighbor
-            right_dist = abs(float(window[right_idx]) - target)
-            # select the closest index and break ties to the left
-            return from_index + (left_idx if left_dist <= right_dist else right_idx)
-        # descending abscissa search on reversed view
-        reversed_window = window[::-1]
-        # insertion index in reversed visible window
-        insert_at = int(np.searchsorted(reversed_window, target, side="left"))
-        # check target is left of the first visible sample in descending order
-        if insert_at <= 0:
-            # clamp to right bound in original ordering
-            return to_index - 1
-        # check target is right of the last visible sample in descending order
-        if insert_at >= window_len:
-            # clamp to left bound in original ordering
-            return from_index
-        # map insertion point neighbors back to original ordering
-        right_idx = window_len - insert_at
-        left_idx = right_idx - 1
-        # distance to left neighbor
-        left_dist = abs(float(window[left_idx]) - target)
-        # distance to right neighbor
-        right_dist = abs(float(window[right_idx]) - target)
-        # select the closest index and break ties to the left
-        return from_index + (left_idx if left_dist <= right_dist else right_idx)
-
-    def sample_abscissa_value_at_ratio(self, x_ratio: float) -> float:
-        # reference step for x mapping, using the first selected step when available
-        reference_step = min(self._selected_steps) if self._selected_steps else 0
-        # reference step slice
-        reference_slice = self._step_information.abscissa_indices[reference_step]
-        # nearest sample index within the current zoom window for the reference step
-        index = self.sample_index_at_ratio(x_ratio)
-        # return stored abscissa value
-        return float(self._abscissa.data[reference_slice.start + index])
+    def _find_abscissa_indexes(self, abscissa: np.ndarray, left_value: float, right_value: float) -> slice:
+        # ascending or descending abscissa
+        ascending = self._step_information.abscissa_ascending
+        # check abscissa is not within the zoom window
+        if (ascending and (abscissa[0] > right_value or abscissa[-1] < left_value)) or (not ascending and (abscissa[0] < right_value or abscissa[-1] > left_value)):
+            return slice(0, 0)
+        # find left and right indexes using binary search
+        left_index = _binary_search(abscissa, left_value, ascending, side=1)
+        right_index = _binary_search(abscissa, right_value, ascending, side=-1)
+        # return slice for values within the zoom window
+        return slice(left_index, right_index)
 
     def _get_expressions_to_plot(self, expression: Expression) -> list[Expression]:
         # check we can plot expression as is
@@ -480,76 +446,59 @@ class Chart:
         return []
 
     def _redraw_all_series(self):
-        # # x0 and x1
-        # abscissa_left_value: float | None = None
-        # abscissa_right_value: float | None = None
-        # try:
-        #     # loop existing series
-        #     for _, (_, ordinate_series) in self._series.items():
-        #         # loop series data (actual data visible in chart)
-        #         for ordinate_variant, (y_axis, rendered_series, _, _, color) in ordinate_series.items():
-        #             # min and max value recalculation for the new zoom window
-        #             min_value = float("inf")
-        #             max_value = float("-inf")
-        #             # loop steps
-        #             for step, series in rendered_series.items():
-        #                 # step slice
-        #                 step_slice = self._step_information.abscissa_indices[step]
-        #                 # local zoom bounds for this step
-        #                 zoom_from_index, zoom_to_index = self._get_step_zoom_bounds(step)
-        #                 # abscissa values
-        #                 abscissa_values = self._abscissa.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
-        #                 # ordinate variant values for this step & zoom window
-        #                 ordinate_values = ordinate_variant.data[step_slice.start + zoom_from_index:step_slice.start + zoom_to_index]
-        #                 # skip inconsistent slices to protect decimation input contracts
-        #                 if abscissa_values.size == 0 or ordinate_values.size == 0 or abscissa_values.size != ordinate_values.size:
-        #                     continue
-        #                 # decimate x and y jointly so every plotted (x, y) pair maps to the same original sample
-        #                 x_np, y_np = decimate_xy(abscissa_values, ordinate_values, self._decimate_target, _DECIMATION_ALGORITHM)
-        #                 # remove Inf values
-        #                 inf_mask = np.isinf(y_np)
-        #                 if inf_mask.any():
-        #                     # mask for finite values
-        #                     keep_mask = ~inf_mask
-        #                     # update x and y with finite values only
-        #                     x_np = x_np[keep_mask]
-        #                     y_np = y_np[keep_mask]
-        #                 # check all values were non-finite after filtering
-        #                 if x_np.size == 0 or y_np.size == 0:
-        #                     continue
-        #                 # update series with decimated data
-        #                 series.replaceNp(x_np, y_np)
-        #                 # update min and max values
-        #                 min_value = min(min_value, float(np.min(y_np)))
-        #                 max_value = max(max_value, float(np.max(y_np)))
-        #                 # update x axis left and right values based on the new zoom window
-        #                 if abscissa_left_value is None or abscissa_right_value is None:
-        #                     # initialize values for the first series processed
-        #                     abscissa_left_value = float(abscissa_values[0])
-        #                     abscissa_right_value = float(abscissa_values[-1])
-        #                 elif abscissa_left_value < abscissa_right_value:
-        #                     # ascending abscissa, update left and right values as needed
-        #                     abscissa_left_value = min(abscissa_left_value, float(abscissa_values[0]))
-        #                     abscissa_right_value = max(abscissa_right_value, float(abscissa_values[-1]))
-        #                 else:
-        #                     # descending abscissa, update left and right values as needed
-        #                     abscissa_left_value = max(abscissa_left_value, float(abscissa_values[0]))
-        #                     abscissa_right_value = min(abscissa_right_value, float(abscissa_values[-1]))
-        #             # calculate scale for Y axis
-        #             scale = max(abs(max_value), abs(min_value))
-        #             # Y axis range
-        #             y_range = max_value - min_value
-        #             if y_range <= scale * 1e-9:
-        #                 y_range = abs(max_value) * 0.01 if scale != 0 else 1.0
-        #             # protect against very small ranges
-        #             delta = max(0.01 * y_range, 1e-3)
-        #             # update dictionary entry
-        #             ordinate_series[ordinate_variant] = (y_axis, rendered_series, min_value - delta, max_value + delta, color)
-        # finally:
-        #     # resize abscissa axis
-        #     if abscissa_left_value is not None and abscissa_right_value is not None:
-        #         self._component.resizeAbscissa(abscissa_left_value, abscissa_right_value)
-        ...
+        # current zoom window in abscissa values, None if not set
+        x_left_ratio, _, x_right_ratio, _ = self._zoom_window
+        # x0 and x1
+        abscissa_left_value = self.ratio_to_abscissa_value(x_left_ratio) if x_left_ratio is not None else self._step_information.abscissa_left_value
+        abscissa_right_value = self.ratio_to_abscissa_value(x_right_ratio) if x_right_ratio is not None else self._step_information.abscissa_right_value
+        try:
+            # loop existing series
+            for _, (_, ordinate_series) in self._series.items():
+                # loop series data (actual data visible in chart)
+                for ordinate_variant, (y_axis, rendered_series, _, _, color) in ordinate_series.items():
+                    # min and max value recalculation for the new zoom window
+                    min_value = float("inf")
+                    max_value = float("-inf")
+                    # loop steps
+                    for step, series in rendered_series.items():
+                        # step slice
+                        step_slice = self._step_information.abscissa_indices[step]
+                        # step abscissa & ordinate values
+                        abscissa_values = self._abscissa.data[step_slice]
+                        ordinate_values_at_abscissa_value = ordinate_variant.data[step_slice]
+                        # check we have a zoom window to apply
+                        if x_left_ratio is not None and x_right_ratio is not None:
+                            # find indexes for the new zoom window
+                            indexes = self._find_abscissa_indexes(abscissa_values, abscissa_left_value, abscissa_right_value)
+                            # abscissa values
+                            abscissa_values = abscissa_values[indexes]
+                            # ordinate variant values for this step & zoom window
+                            ordinate_values_at_abscissa_value = ordinate_values_at_abscissa_value[indexes]
+                        # decimate x and y jointly so every plotted (x, y) pair maps to the same original sample
+                        x_np, y_np = decimate_xy(abscissa_values, ordinate_values_at_abscissa_value, self._decimate_target, _DECIMATION_ALGORITHM)
+                        # remove Inf values
+                        inf_mask = np.isinf(y_np)
+                        if inf_mask.any():
+                            # mask for finite values
+                            keep_mask = ~inf_mask
+                            # update x and y with finite values only
+                            x_np = x_np[keep_mask]
+                            y_np = y_np[keep_mask]
+                        # log information
+                        logger.debug("Updating series for expression [%s], step: %d, original size: %d, decimated size: %d", ordinate_variant.name, step, abscissa_values.size, x_np.size)
+                        # update series with decimated data
+                        series.replaceNp(x_np, y_np)
+                        # skip empty series to protect min/max calculations
+                        if y_np.size == 0:
+                            continue
+                        # update min and max values
+                        min_value = min(min_value, float(np.min(y_np)))
+                        max_value = max(max_value, float(np.max(y_np)))
+                    # update dictionary entry
+                    ordinate_series[ordinate_variant] = (y_axis, rendered_series, min_value, max_value, color)
+        finally:
+            # resize abscissa axis
+            self._component.resizeAbscissa(abscissa_left_value, abscissa_right_value)
 
     def _get_y_axis(self, unit: str) -> QAbstractAxis | None:
         # existing axis for measurement type

--- a/viewer/fft.py
+++ b/viewer/fft.py
@@ -104,8 +104,7 @@ def resample_uniform(x: np.ndarray, y: np.ndarray, num_points: int | None = None
 
     Returns
     -------
-    Tuple *(x_uniform, y_uniform)* on an evenly-spaced grid spanning
-    ``[x[0], x[-1]]``.
+    Tuple *(x_uniform, y_uniform)* on an evenly-spaced grid spanning ``[x[0], x[-1]]``.
     """
     # default to same number of points as the input
     if num_points is None:

--- a/viewer/fft_dialog.py
+++ b/viewer/fft_dialog.py
@@ -1,14 +1,13 @@
 import logging
 from pathlib import Path
 
-import numpy as np
 from PySide6.QtCore import Qt, QUrl, Slot
 from PySide6.QtGui import QColor
 from PySide6.QtQuick import QQuickView
 from PySide6.QtWidgets import QDialog, QVBoxLayout, QWidget
 
 from .expression import Expression
-from .fft import FftOutput, WindowFunction, ZeroPadding, fft_frequency_range
+from .fft import FftOutput, WindowFunction, ZeroPadding
 
 logger = logging.getLogger(__name__)
 
@@ -19,32 +18,28 @@ _BG = "#1a1b1e"
 class FftDialog(QDialog):
     """Dialog for configuring and launching an FFT computation.
 
-    The dialog exposes a QML UI that lets the user choose expressions, data
-    range, window function, zero-padding, normalisation and output format.
-    After acceptance the result properties hold the user's selections.
+    Presents a QML UI for selecting FFT parameters: expressions, data range, window, zero-padding, normalization, output type, and DC option. After acceptance, result properties reflect the user's selections.
 
-    Parameters
-    ----------
-    expressions      : ordinate expressions available for FFT (abscissa excluded).
-    abscissa         : time-domain abscissa expression.
-    zoom_from_index  : left edge of the current visible zoom window (abscissa value).
-    zoom_to_index    : right edge of the current visible zoom window (abscissa value).
-    parent           : optional parent widget.
+    Parameters:
+        parent: QWidget — parent widget
+        expressions: list[Expression] — ordinate expressions for FFT
+        min_abscissa_value: float — minimum abscissa value
+        max_abscissa_value: float — maximum abscissa value
+        min_abscissa_value_zoomed: float — minimum abscissa value in zoom window
+        max_abscissa_value_zoomed: float — maximum abscissa value in zoom window
     """
 
-    def __init__(self, expressions: list[Expression], abscissa: Expression, zoom_from_index: int, zoom_to_index: int, parent=None):
+    def __init__(self, parent: QWidget, expressions: list[Expression], min_abscissa_value: float, max_abscissa_value: float, min_abscissa_value_zoomed: float, max_abscissa_value_zoomed: float):
+        """Initialize the FFT dialog and set up the QML UI. All expressions are pre-selected by default."""
         super().__init__(parent)
         # store references
         self._expressions = expressions
-        self._abscissa = abscissa
-        self._zoom_from_index = zoom_from_index
-        self._zoom_to_index = zoom_to_index
         # selected expressions tracked via selectionChanged signal; all pre-selected
         self._selected_expressions: set[Expression] = set(expressions)
         # result fields populated when the dialog is accepted
         self._result_expressions: list[Expression] = []
-        self._result_from_index: float = float(abscissa.data[0])
-        self._result_to_index: float = float(abscissa.data[-1])
+        self._result_from_index: float = float(min_abscissa_value)
+        self._result_to_index: float = float(max_abscissa_value)
         self._result_window: WindowFunction = WindowFunction.HANNING
         self._result_zero_pad: ZeroPadding = ZeroPadding.NONE
         self._result_normalize: bool = False
@@ -55,21 +50,15 @@ class FftDialog(QDialog):
         self.setWindowModality(Qt.WindowModality.WindowModal)
         self.resize(480, 650)
         self.setMinimumHeight(650)
-        # compute frequency-range preview from the full abscissa
-        abscissa_values = abscissa.data
-        df, f_nyquist = fft_frequency_range(abscissa_values)
         # expose data to QML via context properties
-        # build the initial property values for the QML root object
         self._ctx_properties = {
             "windowFunctions": [w.value for w in WindowFunction],
             "outputTypes": [o.value for o in FftOutput],
             "zeroPaddingOptions": [z.value for z in ZeroPadding],
-            "freqRangePreview": f"0 Hz – {f_nyquist:.4g} Hz (Nyquist)",
-            "binWidthPreview": f"{df:.4g} Hz / bin",
-            "abscissaMin": float(abscissa_values[0]),
-            "abscissaMax": float(abscissa_values[-1]),
-            "zoomFromTime": float(zoom_from_index),
-            "zoomToTime": float(zoom_to_index),
+            "abscissaMin": min_abscissa_value,
+            "abscissaMax": max_abscissa_value,
+            "zoomFromTime": min_abscissa_value_zoomed,
+            "zoomToTime": max_abscissa_value_zoomed,
             "defaultWindowIndex": [w.value for w in WindowFunction].index(WindowFunction.HANNING.value),
         }
         # create QML view
@@ -86,6 +75,7 @@ class FftDialog(QDialog):
 
     @Slot(QQuickView.Status)
     def _on_qml_ready(self, status: QQuickView.Status):
+        """Inject context properties and connect QML signals after QML is ready."""
         # only proceed once QML has finished loading successfully
         if status != QQuickView.Status.Ready:
             return
@@ -102,6 +92,7 @@ class FftDialog(QDialog):
 
     @Slot(str, bool)
     def _on_expression_selection_changed(self, name: str, selected: bool):
+        """Update selected expressions when user toggles an expression in the QML UI."""
         # find the matching expression and toggle it in the selected set
         expression = next((e for e in self._expressions if e.name == name), None)
         if expression is None:
@@ -113,28 +104,31 @@ class FftDialog(QDialog):
 
     @Slot(str, str, str, bool, str, float, float, bool)
     def _on_dialog_accepted(self, window_fn: str, zero_pad: str, output: str, normalize: bool, range_mode: str, custom_from: float, custom_to: float, keep_dc: bool):
+        """Validate selection, store result properties, and close the dialog when accepted from QML UI."""
         # reject if no expressions are selected
         if not self._selected_expressions:
             # log warning and reject dialog when no expressions are selected
             logger.warning("FFT dialog accepted with no expressions selected")
+            # reject dialog
             self.reject()
+            # exit
             return
         # store resolved expressions preserving their original list order
         self._result_expressions = [e for e in self._expressions if e in self._selected_expressions]
-        # window function
         try:
+            # window function
             self._result_window = WindowFunction(window_fn)
         except ValueError:
             # fall back to rectangular when the value is unrecognised
             self._result_window = WindowFunction.RECTANGULAR
-        # zero-padding
         try:
+            # zero-padding
             self._result_zero_pad = ZeroPadding(zero_pad)
         except ValueError:
             # fall back to no padding when the value is unrecognised
             self._result_zero_pad = ZeroPadding.NONE
-        # output type
         try:
+            # output type
             self._result_output = FftOutput(output)
         except ValueError:
             # fall back to magnitude when the value is unrecognised
@@ -143,39 +137,45 @@ class FftDialog(QDialog):
         self._result_normalize = normalize
         # keep dc flag
         self._result_keep_dc = keep_dc
-        # data range
-        abscissa_values = self._abscissa.data
         # proceed to accept the dialog and close it
         self.accept()
 
     @property
     def result_expressions(self) -> list[Expression]:
+        """List of expressions selected for FFT (original order)."""
         return self._result_expressions
 
     @property
     def result_from_index(self) -> float:
+        """Left edge of the selected abscissa range."""
         return self._result_from_index
 
     @property
     def result_to_index(self) -> float:
+        """Right edge of the selected abscissa range."""
         return self._result_to_index
 
     @property
     def result_window(self) -> WindowFunction:
+        """Selected window function for FFT."""
         return self._result_window
 
     @property
     def result_zero_pad(self) -> ZeroPadding:
+        """Selected zero-padding option for FFT."""
         return self._result_zero_pad
 
     @property
     def result_normalize(self) -> bool:
+        """Whether normalization is enabled for FFT output."""
         return self._result_normalize
 
     @property
     def result_keep_dc(self) -> bool:
+        """Whether to keep the DC component in FFT output."""
         return self._result_keep_dc
 
     @property
     def result_output(self) -> FftOutput:
+        """Selected FFT output type (e.g., magnitude, phase)."""
         return self._result_output

--- a/viewer/fft_dialog.py
+++ b/viewer/fft_dialog.py
@@ -27,8 +27,8 @@ class FftDialog(QDialog):
     ----------
     expressions      : ordinate expressions available for FFT (abscissa excluded).
     abscissa         : time-domain abscissa expression.
-    zoom_from_index  : left edge of the current visible zoom window (sample index).
-    zoom_to_index    : right edge of the current visible zoom window (sample index).
+    zoom_from_index  : left edge of the current visible zoom window (abscissa value).
+    zoom_to_index    : right edge of the current visible zoom window (abscissa value).
     parent           : optional parent widget.
     """
 
@@ -43,8 +43,8 @@ class FftDialog(QDialog):
         self._selected_expressions: set[Expression] = set(expressions)
         # result fields populated when the dialog is accepted
         self._result_expressions: list[Expression] = []
-        self._result_from_index: int = 0
-        self._result_to_index: int = len(abscissa.data)
+        self._result_from_index: float = float(abscissa.data[0])
+        self._result_to_index: float = float(abscissa.data[-1])
         self._result_window: WindowFunction = WindowFunction.HANNING
         self._result_zero_pad: ZeroPadding = ZeroPadding.NONE
         self._result_normalize: bool = False
@@ -68,8 +68,8 @@ class FftDialog(QDialog):
             "binWidthPreview": f"{df:.4g} Hz / bin",
             "abscissaMin": float(abscissa_values[0]),
             "abscissaMax": float(abscissa_values[-1]),
-            "zoomFromTime": float(abscissa_values[min(zoom_from_index, len(abscissa_values) - 1)]),
-            "zoomToTime": float(abscissa_values[min(zoom_to_index, len(abscissa_values)) - 1]),
+            "zoomFromTime": float(zoom_from_index),
+            "zoomToTime": float(zoom_to_index),
             "defaultWindowIndex": [w.value for w in WindowFunction].index(WindowFunction.HANNING.value),
         }
         # create QML view
@@ -145,23 +145,6 @@ class FftDialog(QDialog):
         self._result_keep_dc = keep_dc
         # data range
         abscissa_values = self._abscissa.data
-        # total number of abscissa samples
-        total = len(abscissa_values)
-        if range_mode == "zoom":
-            # use the current visible zoom window
-            self._result_from_index = self._zoom_from_index
-            self._result_to_index = self._zoom_to_index
-        elif range_mode == "custom":
-            # map user-supplied time values to nearest sample indices
-            from_idx = int(np.searchsorted(abscissa_values, custom_from))
-            to_idx = int(np.searchsorted(abscissa_values, custom_to, side="right"))
-            # clamp to valid range ensuring at least 2 samples
-            self._result_from_index = max(0, min(from_idx, total - 2))
-            self._result_to_index = max(self._result_from_index + 2, min(to_idx, total))
-        else:
-            # use the full abscissa range
-            self._result_from_index = 0
-            self._result_to_index = total
         # proceed to accept the dialog and close it
         self.accept()
 
@@ -170,11 +153,11 @@ class FftDialog(QDialog):
         return self._result_expressions
 
     @property
-    def result_from_index(self) -> int:
+    def result_from_index(self) -> float:
         return self._result_from_index
 
     @property
-    def result_to_index(self) -> int:
+    def result_to_index(self) -> float:
         return self._result_to_index
 
     @property

--- a/viewer/fft_dialog.qml
+++ b/viewer/fft_dialog.qml
@@ -11,8 +11,6 @@ Item {
     property var windowFunctions: []
     property var outputTypes: []
     property var zeroPaddingOptions: []
-    property string freqRangePreview: ""
-    property string binWidthPreview: ""
     property real abscissaMin: 0
     property real abscissaMax: 0
     property real zoomFromTime: 0
@@ -560,36 +558,6 @@ Item {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: keepDcCheck.checked = !keepDcCheck.checked
-                }
-            }
-
-            // ---------------------------------------------------------------
-            // Section: Preview
-            // ---------------------------------------------------------------
-            Rectangle {
-                width: parent.width
-                implicitHeight: previewColumn.implicitHeight + 16
-                radius: 4
-                color: "#14151a"
-                border.color: "#2a2d35"
-                border.width: 1
-
-                Column {
-                    id: previewColumn
-                    anchors { fill: parent; margins: 8 }
-                    spacing: 4
-
-                    Row {
-                        spacing: 6
-                        Text { text: "Frequency range:"; color: "#7a8599"; font.pixelSize: 11; width: 110 }
-                        Text { text: root.freqRangePreview; color: "#b0b8c8"; font.pixelSize: 11 }
-                    }
-
-                    Row {
-                        spacing: 6
-                        Text { text: "Bin resolution:"; color: "#7a8599"; font.pixelSize: 11; width: 110 }
-                        Text { text: root.binWidthPreview; color: "#b0b8c8"; font.pixelSize: 11 }
-                    }
                 }
             }
         }

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -311,9 +311,6 @@ class MainWindow(QMainWindow):
     def _on_menu_zoom_to_fit(self, chart_index: int):
         # log information
         logger.debug("User requested zoom to fit on chart at index: %d", chart_index)
-        # reset fields
-        self.x_left_ratio = 0.0
-        self.x_right_ratio = 1.0
         # update charts
         for index, chart in enumerate(self._charts):
             # check if this is the chart that triggered the zoom to fit action
@@ -338,9 +335,6 @@ class MainWindow(QMainWindow):
     def _on_menu_zoom_abscissa_extent(self, chart_index: int):
         # log information
         logger.debug("User requested zoom abscissa extent on chart at index: %d", chart_index)
-        # reset fields
-        self.x_left_ratio = 0.0
-        self.x_right_ratio = 1.0
         # update charts
         for chart in self._charts:
             # update zoom window
@@ -445,128 +439,143 @@ class MainWindow(QMainWindow):
 
     @Slot(int)
     def _on_menu_fft(self, chart_index: int):
-        # # log information
-        # logger.debug("User requested FFT on chart at index: %d", chart_index)
-        # # find chart
-        # chart = self._charts[chart_index]
-        # # collect real-valued ordinate expressions currently plotted on this chart
-        # expressions = [v for v in chart.expressions if not v.complex and v != chart.abscissa]
-        # if not expressions:
-        #     # log warning — no suitable expressions to transform
-        #     logger.warning("No suitable time-domain expressions to FFT on chart %d", chart_index)
-        #     # exit
-        #     return
-        # # open FFT settings dialog
-        # reference_step = min(chart.selected_steps) if chart.selected_steps else 0
-        # reference_slice = self._step_information.abscissa_indices[reference_step]
-        # fft_abscissa = Expression(self._abscissa.name, self._abscissa.data[reference_slice], self._abscissa.unit, self._abscissa.source, self._abscissa.variable_type)
-        # dialog = FftDialog(expressions, fft_abscissa, self._abscissa_from_index, self._abscissa_to_index, self)
-        # if dialog.exec() != FftDialog.DialogCode.Accepted:
-        #     return
-        # # retrieve user selections
-        # result_expressions = dialog.result_expressions
-        # from_index = dialog.result_from_index
-        # to_index = dialog.result_to_index
-        # window = dialog.result_window
-        # zero_pad = dialog.result_zero_pad
-        # normalize = dialog.result_normalize
-        # keep_dc = dialog.result_keep_dc
-        # output = dialog.result_output
-        # # number of samples per step (abscissa is already trimmed to one step)
-        # step_count = self._step_information.length
-        # # build FFT step slices and values for each input step independently to support variable step lengths
-        # fft_step_indices: list[slice] = []
-        # fft_source_steps: list[int] = []
-        # frequency_chunks: list[np.ndarray] = []
-        # fft_chunks: list[list[np.ndarray]] = [[] for _ in result_expressions]
-        # # running index over the flattened FFT vectors
-        # fft_offset = 0
-        # # rows are [expr0, expr1, ..., exprN] for one step per FFT call
-        # signal_count = len(result_expressions)
-        # # process each source step independently to avoid assuming equal step lengths
-        # for step_index in range(step_count):
-        #     # source step slice in flattened arrays
-        #     step_slice = self._step_information.abscissa_indices[step_index]
-        #     # number of source samples in this step
-        #     step_points = step_slice.stop - step_slice.start
-        #     # clamp global zoom bounds to this step and keep at least two samples
-        #     if step_points < 2:
-        #         continue
-        #     step_from_index = max(0, min(from_index, step_points - 2))
-        #     step_to_index = max(step_from_index + 2, min(to_index, step_points))
-        #     # absolute array bounds for this step's FFT window
-        #     source_from_index = step_slice.start + step_from_index
-        #     source_to_index = step_slice.start + step_to_index
-        #     # shared x slice for this step
-        #     x = self._abscissa.data[source_from_index:source_to_index]
-        #     # build a dense matrix for all selected expressions for this step
-        #     y_matrix = np.empty((signal_count, source_to_index - source_from_index))
-        #     # fill matrix row-by-row using contiguous slices
-        #     for expr_index, expression in enumerate(result_expressions):
-        #         y_matrix[expr_index] = expression.data[source_from_index:source_to_index]
-        #     try:
-        #         # fft internals allocate output arrays (spectrum/frequency/value matrices)
-        #         frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
-        #     except ValueError:
-        #         # log exception and abort
-        #         logger.exception("Batch FFT computation failed for chart %d step %d", chart_index, step_index)
-        #         # exit
-        #         return
-        #     # guard against an unexpectedly empty frequency axis
-        #     if len(frequencies) == 0:
-        #         # log error and abort when no frequencies are returned
-        #         logger.error("FFT computation returned an empty frequency axis for chart %d step %d", chart_index, step_index)
-        #         # exit
-        #         return
-        #     # append frequency bins for this step
-        #     frequency_chunks.append(frequencies)
-        #     # append source step index for later selection mapping
-        #     fft_source_steps.append(step_index)
-        #     # append per-expression FFT values for this step
-        #     for expr_index in range(signal_count):
-        #         fft_chunks[expr_index].append(fft_matrix[expr_index])
-        #     # store step output slice for the FFT result vectors
-        #     fft_step_indices.append(slice(fft_offset, fft_offset + len(frequencies)))
-        #     # advance output offset
-        #     fft_offset += len(frequencies)
-        # # require at least one processed step
-        # if not frequency_chunks:
-        #     # log warning and abort when no step had enough samples for FFT
-        #     logger.warning("FFT computation skipped: no step has at least 2 samples in the selected range")
-        #     # exit
-        #     return
-        # fft_expressions: list[Expression] = []
-        # for expr_index, expression in enumerate(result_expressions):
-        #     # flatten all per-step chunks for this expression into one step-major vector
-        #     expression_data = np.concatenate(fft_chunks[expr_index])
-        #     expression_unit = "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)
-        #     fft_expressions.append(Expression(f"FFT({expression.name.replace(' ', '')})", expression_data, expression_unit))
-        # # flatten per-step frequency bins into one step-major vector
-        # frequency_data = np.concatenate(frequency_chunks)
-        # # create frequency expression with per-step variable lengths
-        # freq_expression = Expression("Frequency", frequency_data, "Hz")
-        # # build expression manager with frequency abscissa and all FFT results
-        # expression_manager = ExpressionManager([freq_expression] + fft_expressions)
-        # # build one «name» group per FFT expression so each gets its own chart
-        # plot_suggestion = " ".join(f"\xabfft {e.name}\xbb" for e in fft_expressions)
-        # # map source parameter values onto FFT steps
-        # fft_step_values = [self._step_information.values[index] for index in fft_source_steps]
-        # # create step information for FFT output
-        # fft_step_information = StepInformation(self._step_information.keys, fft_step_values, fft_step_indices)
-        # # create a synthetic QRawFile with frequency abscissa and all FFT values;
-        # # steps matches the source simulation so the FFT window inherits full step coverage
-        # fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT – {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, step_information=fft_step_information, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
-        # # create a new MainWindow to render the FFT result using the existing infrastructure;
-        # # pass the original source path so Jupyter always opens the correct .qraw file
-        # fft_window = MainWindow(fft_qraw, source_qraw_path=self._qraw_path)
-        # # pre-focus the FFT window on the same steps the user was viewing in the source chart
-        # source_to_fft_index = {source_step: fft_step for fft_step, source_step in enumerate(fft_source_steps)}
-        # fft_window._initial_selected_steps = {source_to_fft_index[source_step] for source_step in chart.selected_steps if source_step in source_to_fft_index}
-        # # keep reference alive independently of the source main window
-        # _register_child_window(fft_window)
-        # # show the FFT result window
-        # fft_window.show()
-        ...
+        # log information
+        logger.debug("User requested FFT on chart at index: %d", chart_index)
+        # find chart
+        chart = self._charts[chart_index]
+        # collect real-valued ordinate expressions currently plotted on this chart
+        expressions = [v for v in chart.expressions if not v.complex and v != chart.abscissa]
+        if not expressions:
+            # log warning — no suitable expressions to transform
+            logger.warning("No suitable time-domain expressions to FFT on chart %d", chart_index)
+            # exit
+            return
+        # min and max abscissa values (time domain abscissa is always ascending order)
+        min_abscissa_value = self._step_information.abscissa_left_value
+        max_abscissa_value = self._step_information.abscissa_right_value
+        # current chart zoom ratios for the abscissa axis (0.0 to 1.0)
+        x_left_ratio, _, x_right_ratio, _ = chart.zoom_window
+        # apply selected chart zoom
+        min_abscissa_value_zoomed = min_abscissa_value + (x_left_ratio or 0.0) * (max_abscissa_value - min_abscissa_value)
+        max_abscissa_value_zoomed = min_abscissa_value + (x_right_ratio or 1.0) * (max_abscissa_value - min_abscissa_value)
+        # open FFT settings dialog
+        dialog = FftDialog(self, expressions, min_abscissa_value, max_abscissa_value, min_abscissa_value_zoomed, max_abscissa_value_zoomed)
+        # check if the user accepted the dialog; if not, exit without doing anything
+        if dialog.exec() != FftDialog.DialogCode.Accepted:
+            return
+        # retrieve user selections
+        result_expressions = dialog.result_expressions
+        from_abscissa_value = dialog.result_from_index
+        to_abscissa_value = dialog.result_to_index
+        window = dialog.result_window
+        zero_pad = dialog.result_zero_pad
+        normalize = dialog.result_normalize
+        keep_dc = dialog.result_keep_dc
+        output = dialog.result_output
+        # list of frequency bins for each step, to be concatenated across steps later
+        frequency_chunks: list[np.ndarray] = []
+        # fft data chunks for each expression, to be concatenated across steps later; outer list is per-expression, inner list is per-step
+        fft_chunks: list[list[np.ndarray]] = [[] for _ in result_expressions]
+        # fft step & step indices for step information structure
+        fft_steps: list[int] = []
+        fft_abscissa_indices: list[slice] = []
+        # step abscissa value ranges
+        fft_abscissa_value_ranges: list[tuple[float, float]] = []
+        # fft step index offset
+        fft_offset = 0
+        # loop steps
+        for step in range(self._step_information.length):
+            # step data slice
+            step_slice = self._step_information.abscissa_indices[step]
+            # abscissa values for this step
+            step_abscissa = self._abscissa.data[step_slice]
+            # find indices in this step corresponding to the selected abscissa range
+            from_index = np.searchsorted(step_abscissa, from_abscissa_value, side="left")
+            to_index = np.searchsorted(step_abscissa, to_abscissa_value, side="right")
+            # we require at least 2 samples in the selected range to perform an FFT, otherwise skip this step
+            if to_index - from_index < 2:
+                # log warning and skip this step when it has fewer than 2 samples in the selected range
+                logger.warning("Skipping FFT for chart %d step %d: selected range has fewer than 2 samples", chart_index, step)
+                # next step
+                continue
+            # abscissa data for the interval
+            step_abscissa_data = step_abscissa[from_index:to_index]
+            # rows are [expr0, expr1, ..., exprN] for one step per FFT call
+            signal_count = len(result_expressions)
+            # build a dense matrix for all selected expressions for this step
+            y_matrix = np.empty((signal_count, to_index - from_index))
+            # fill matrix row-by-row using contiguous slices
+            for expr_index, expression in enumerate(result_expressions):
+                # expression data for this step
+                expression_step_data = expression.data[step_slice]
+                # slice out the selected abscissa range for this expression and store it in the matrix
+                y_matrix[expr_index] = expression_step_data[from_index:to_index]
+            try:
+                # fft internals allocate output arrays (spectrum/frequency/value matrices)
+                frequencies, fft_matrix = compute_fft_many(step_abscissa_data, y_matrix, window, zero_pad, normalize, output, keep_dc)
+                # guard against an unexpectedly empty frequency axis
+                if len(frequencies) == 0:
+                    # log error and abort when no frequencies are returned
+                    logger.error("FFT computation returned an empty frequency axis for chart %d step %d", chart_index, step)
+                    # exit
+                    return
+                # append frequency bins for this step
+                frequency_chunks.append(frequencies)
+                #  append per-expression FFT values for this step
+                for expr_index in range(signal_count):
+                    fft_chunks[expr_index].append(fft_matrix[expr_index])
+                # store step output slice for the FFT result vectors
+                fft_abscissa_indices.append(slice(fft_offset, fft_offset + len(frequencies)))
+                # advance output offset
+                fft_offset += len(frequencies)
+                # append step as processed
+                fft_steps.append(step)
+                # append abscissa value range for this step
+                fft_abscissa_value_ranges.append((frequencies[0], frequencies[-1]))
+            except ValueError:
+                # log exception and abort
+                logger.exception("Batch FFT computation failed for chart %d step %d", chart_index, step)
+                # exit
+                return
+        # require at least one processed step
+        if not frequency_chunks:
+            # log warning and abort when no step had enough samples for FFT
+            logger.warning("FFT computation skipped: no step has at least 2 samples in the selected range")
+            # exit
+            return
+        # build fft expressions
+        fft_expressions: list[Expression] = []
+        # loop processed expressions
+        for expr_index, expression in enumerate(result_expressions):
+            # flatten all per-step chunks for this expression into one step-major vector
+            expression_data = np.concatenate(fft_chunks[expr_index])
+            # unit
+            expression_unit = "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)
+            # create expression for this FFT result
+            fft_expressions.append(Expression(f"FFT({expression.name.replace(' ', '')})", expression_data, expression_unit))
+        # flatten per-step frequency bins into one step-major vector
+        frequency_data = np.concatenate(frequency_chunks)
+        # create frequency expression with per-step variable lengths
+        freq_expression = Expression("Frequency", frequency_data, "Hz")
+        # build expression manager with frequency abscissa and all FFT results
+        expression_manager = ExpressionManager([freq_expression] + fft_expressions)
+        # build one «name» group per FFT expression so each gets its own chart
+        plot_suggestion = " ".join(f"\xabfft {e.name}\xbb" for e in fft_expressions)
+        # map source parameter values onto FFT steps (only available when there are multiple steps, otherwise leave empty)
+        fft_values = [self._step_information.values[index] for index in fft_steps] if self._step_information.length > 1 else []
+        # create step information for FFT output
+        fft_step_information = StepInformation(self._step_information.keys, fft_values, fft_abscissa_indices, fft_abscissa_value_ranges)
+        # create qraw file with fft calculation results
+        fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT – {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, step_information=fft_step_information, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
+        # create a new MainWindow to render the FFT result
+        fft_window = MainWindow(fft_qraw, source_qraw_path=self._qraw_path)
+        # pre-focus the FFT window on the same steps the user was viewing in the source chart
+        source_to_fft_index = {source_step: fft_step for fft_step, source_step in enumerate(fft_steps)}
+        fft_window._initial_selected_steps = {source_to_fft_index[source_step] for source_step in chart.selected_steps if source_step in source_to_fft_index}
+        # keep reference alive independently of the source main window
+        _register_child_window(fft_window)
+        # show the FFT result window
+        fft_window.show()
 
     @Slot(int, float)
     def _on_pointer_moved(self, chart_index: int, x_ratio: float):

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -177,8 +177,7 @@ class MainWindow(QMainWindow):
         self._root.setProperty("fftEnabled", bool(self._abscissa.unit == "s"))
         self._root.setProperty("stepToolEnabled", bool(self._step_information.length > 1))
         # connect signals from QML to Python handlers
-        self._root.horizontalZoom.connect(self._on_horizontal_zoom)
-        self._root.verticalZoom.connect(self._on_vertical_zoom)
+        self._root.zoomRegionSelected.connect(self._on_zoom_region_selected)
         self._root.menuZoomToFit.connect(self._on_menu_zoom_to_fit)
         self._root.menuAutorange.connect(self._on_menu_autorange)
         self._root.menuZoomAbscissaExtent.connect(self._on_menu_zoom_abscissa_extent)
@@ -230,6 +229,7 @@ class MainWindow(QMainWindow):
         add_chart_action = QAction("Add Chart", self)
         add_chart_action.triggered.connect(lambda: self._on_menu_add_chart(len(self._charts) - 1))
         window_menu.addAction(add_chart_action)
+
         # Window | New Window
         new_window_action = QAction("New Window", self)
         new_window_action.triggered.connect(self._on_menu_new_window)
@@ -237,6 +237,7 @@ class MainWindow(QMainWindow):
 
         # Help menu
         help_menu = menu_bar.addMenu("&Help")
+
         # Help | About
         about_action = QAction("About", self)
         about_action.triggered.connect(lambda: None)
@@ -291,80 +292,38 @@ class MainWindow(QMainWindow):
         # render chart
         chart.render("", self._abscissa_scale.value, set(expressions))
 
-    @Slot(int, float, float, float)
-    def _on_horizontal_zoom(self, chart_index: int, x_left_ratio: float, x_right_ratio: float, zoom_factor: float):
-        # # calculate horizontal axis indices from the supplied ratios
-        # total = self._step_information.abscissa_to_index
-        # from_index = max(0, min(int(self._abscissa_from_index + x_left_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total - 1))
-        # to_index = max(0, min(int(self._abscissa_from_index + x_right_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total))
-        # # allow zoom-in beyond pixel width, only enforce a minimum window of 2 points
-        # min_window = 2
-        # # detect pure pan (translation) gestures: when the ratio span equals 1.0
-        # ratio_span = x_right_ratio - x_left_ratio
-        # # current window before the operation
-        # current_from = self._abscissa_from_index
-        # current_to = self._abscissa_to_index
-        # current_window = current_to - current_from
-        # # small epsilon for floating comparisons
-        # if abs(ratio_span - 1.0) < 1e-9 or zoom_factor == 1.0:
-        #     # this is a pan: compute integer shift in samples and apply
-        #     shift = int(round(x_left_ratio * current_window))
-        #     new_from = max(0, min(total - current_window, current_from + shift))
-        #     new_to = new_from + current_window
-        #     from_index = new_from
-        #     to_index = new_to
-        # else:
-        #     # choose direction based on factor (<1 zoom-in, >1 zoom-out)
-        #     window = to_index - from_index
-        #     mid = (from_index + to_index) // 2
-        #     step = max(1, window // 8)
-        #     if window < min_window:
-        #         from_index = max(0, mid - min_window // 2)
-        #         to_index = min(total, from_index + min_window)
-        #     elif zoom_factor > 1.0:
-        #         # zoom-out: expand window by a small step, up to full range
-        #         new_window = min(total, window + step)
-        #         from_index = max(0, mid - new_window // 2)
-        #         to_index = min(total, from_index + new_window)
-        #     else:
-        #         # zoom-in: reduce window by a small step, down to min_window
-        #         new_window = max(min_window, window - step)
-        #         from_index = max(0, mid - new_window // 2)
-        #         to_index = min(total, from_index + new_window)
-        # # update fields
-        # self._abscissa_from_index = from_index
-        # self._abscissa_to_index = to_index
-        # # update all charts — horizontal zoom is shared across all panels
-        # for chart in self._charts:
-        #     # update zoom window — pass None for Y to leave per-chart vertical zoom unchanged
-        #     chart.update_zoom_window(from_index, to_index, None, None)
-        ...
-
-    @Slot(int, float, float)
-    def _on_vertical_zoom(self, chart_index: int, y_top_ratio: float, y_bottom_ratio: float):
-        # find chart at index
-        chart = self._charts[chart_index]
-        # update vertical zoom window only — pass -1 for horizontal indices to leave them unchanged
-        chart.update_zoom_window(-1, -1, y_top_ratio, y_bottom_ratio)
+    @Slot(int, float, float, float, float)
+    def _on_zoom_region_selected(self, chart_index: int, x_left_ratio: float, y_top_ratio: float, x_right_ratio: float, y_bottom_ratio: float):
+        # log information
+        logger.debug("User requested zoom region on chart at index: %d, rectangle: (%.3f, %.3f) to (%.3f, %.3f)", chart_index, x_left_ratio, y_top_ratio, x_right_ratio, y_bottom_ratio)
+        # update charts
+        for index, chart in enumerate(self._charts):
+            # check if this is the chart that triggered the zoom to fit action
+            if index == chart_index:
+                # reset zoom window
+                chart.update_zoom_window(min(x_left_ratio, x_right_ratio), max(x_left_ratio, x_right_ratio), min(y_top_ratio, y_bottom_ratio), max(y_top_ratio, y_bottom_ratio))
+                # next
+                continue
+            # update horizontal zoom window only, keep vertical zoom as is
+            chart.update_zoom_window(min(x_left_ratio, x_right_ratio), max(x_left_ratio, x_right_ratio), None, None)
 
     @Slot(int)
     def _on_menu_zoom_to_fit(self, chart_index: int):
-        # # log information
-        # logger.debug("User requested zoom to fit on chart at index: %d", chart_index)
-        # # reset horizontal axis indices to show the full range of the abscissa
-        # self._abscissa_from_index = self._step_information.abscissa_from_index
-        # self._abscissa_to_index = self._step_information.abscissa_to_index
-        # # update charts
-        # for index, chart in enumerate(self._charts):
-        #     # check if this is the chart that triggered the zoom to fit action
-        #     if index == chart_index:
-        #         # reset zoom window
-        #         chart.reset_zoom_window(self._abscissa_from_index, self._abscissa_to_index, 0.0, 1.0)
-        #         # next
-        #         continue
-        #     # update horizontal zoom window only, keep vertical zoom as is
-        #     chart.update_zoom_window(self._abscissa_from_index, self._abscissa_to_index, None, None)
-        ...
+        # log information
+        logger.debug("User requested zoom to fit on chart at index: %d", chart_index)
+        # reset fields
+        self.x_left_ratio = 0.0
+        self.x_right_ratio = 1.0
+        # update charts
+        for index, chart in enumerate(self._charts):
+            # check if this is the chart that triggered the zoom to fit action
+            if index == chart_index:
+                # reset zoom window
+                chart.reset_zoom_window(True, True)
+                # next
+                continue
+            # update horizontal zoom window only, keep vertical zoom as is
+            chart.reset_zoom_window(True, False)
 
     @Slot(int)
     def _on_menu_autorange(self, chart_index: int):
@@ -373,20 +332,19 @@ class MainWindow(QMainWindow):
         # find chart at index
         chart = self._charts[chart_index]
         # reset zoom window
-        chart.reset_zoom_window(-1, -1, 0.0, 1.0)
+        chart.reset_zoom_window(False, True)
 
     @Slot(int)
     def _on_menu_zoom_abscissa_extent(self, chart_index: int):
-        # # log information
-        # logger.debug("User requested zoom abscissa extent on chart at index: %d", chart_index)
-        # # update fields
-        # self._abscissa_from_index = self._step_information.abscissa_from_index
-        # self._abscissa_to_index = self._step_information.abscissa_to_index
-        # # update charts
-        # for chart in self._charts:
-        #     # update zoom window
-        #     chart.reset_zoom_window(self._abscissa_from_index, self._abscissa_to_index, None, None)
-        ...
+        # log information
+        logger.debug("User requested zoom abscissa extent on chart at index: %d", chart_index)
+        # reset fields
+        self.x_left_ratio = 0.0
+        self.x_right_ratio = 1.0
+        # update charts
+        for chart in self._charts:
+            # update zoom window
+            chart.reset_zoom_window(True, False)
 
     @Slot(int)
     def _on_menu_add_remove_plots(self, chart_index: int):
@@ -624,7 +582,7 @@ class MainWindow(QMainWindow):
         # chart at index
         chart = self._charts[chart_index]
         # retrieve the stored abscissa value (may be in log space for decade/octave scales)
-        x_stored = chart.sample_abscissa_value_at_ratio(x_ratio)
+        x_stored = chart.ratio_to_abscissa_value(x_ratio)
         # convert stored value back to physical abscissa value
         if self._abscissa_scale == AbscissaScale.DECADE:
             x_actual = 10 ** x_stored
@@ -635,10 +593,10 @@ class MainWindow(QMainWindow):
         # append abscissa value
         parts = [_format_values(self._abscissa.name, [x_actual], self._abscissa.unit)]
         # process samples from chart
-        for name, unit, values in chart.sample_at(x_ratio):
+        for name, unit, values in chart.ordinate_values_at_abscissa_value(x_stored):
             parts.append(_format_values(name, values, unit))
         # update status bar with the composed string
-        self.statusBar().showMessage("    ".join(parts))
+        self.statusBar().showMessage("  ".join(parts))
 
     @Slot(int)
     def _on_pointer_exited(self, chart_index: int):

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -139,9 +139,6 @@ class MainWindow(QMainWindow):
         self._initial_selected_steps: set[int] | None = None
         # keep Jupyter windows alive to prevent garbage collection
         self._jupyter_windows: list[JupyterWindow] = []
-        # default horizontal zoom
-        self._abscissa_from_index = self._step_information.abscissa_from_index
-        self._abscissa_to_index = self._step_information.abscissa_to_index
         # single QQuickView hosts the entire multi-chart scene — one Metal swap chain
         self._qml_view = QQuickView()
         self._qml_view.statusChanged.connect(self._on_qml_ready)
@@ -285,7 +282,7 @@ class MainWindow(QMainWindow):
         # get a reference to the chart's QML object so we can manipulate it
         chart_root = self._root.getChart(chart_index)
         # create chart instance
-        chart = Chart(chart_root, chart_type, self._expression_manager, self._abscissa, self._abscissa_from_index, self._abscissa_to_index, self._step_information, self._decimate_target)
+        chart = Chart(chart_root, chart_type, self._expression_manager, self._abscissa, self._step_information, self._decimate_target)
         # apply initial step selection when provided (e.g. FFT window inheriting source chart visibility)
         if self._initial_selected_steps is not None:
             chart.selected_steps = self._initial_selected_steps
@@ -296,51 +293,52 @@ class MainWindow(QMainWindow):
 
     @Slot(int, float, float, float)
     def _on_horizontal_zoom(self, chart_index: int, x_left_ratio: float, x_right_ratio: float, zoom_factor: float):
-        # calculate horizontal axis indices from the supplied ratios
-        total = self._step_information.abscissa_to_index
-        from_index = max(0, min(int(self._abscissa_from_index + x_left_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total - 1))
-        to_index = max(0, min(int(self._abscissa_from_index + x_right_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total))
-        # allow zoom-in beyond pixel width, only enforce a minimum window of 2 points
-        min_window = 2
-        # detect pure pan (translation) gestures: when the ratio span equals 1.0
-        ratio_span = x_right_ratio - x_left_ratio
-        # current window before the operation
-        current_from = self._abscissa_from_index
-        current_to = self._abscissa_to_index
-        current_window = current_to - current_from
-        # small epsilon for floating comparisons
-        if abs(ratio_span - 1.0) < 1e-9 or zoom_factor == 1.0:
-            # this is a pan: compute integer shift in samples and apply
-            shift = int(round(x_left_ratio * current_window))
-            new_from = max(0, min(total - current_window, current_from + shift))
-            new_to = new_from + current_window
-            from_index = new_from
-            to_index = new_to
-        else:
-            # choose direction based on factor (<1 zoom-in, >1 zoom-out)
-            window = to_index - from_index
-            mid = (from_index + to_index) // 2
-            step = max(1, window // 8)
-            if window < min_window:
-                from_index = max(0, mid - min_window // 2)
-                to_index = min(total, from_index + min_window)
-            elif zoom_factor > 1.0:
-                # zoom-out: expand window by a small step, up to full range
-                new_window = min(total, window + step)
-                from_index = max(0, mid - new_window // 2)
-                to_index = min(total, from_index + new_window)
-            else:
-                # zoom-in: reduce window by a small step, down to min_window
-                new_window = max(min_window, window - step)
-                from_index = max(0, mid - new_window // 2)
-                to_index = min(total, from_index + new_window)
-        # update fields
-        self._abscissa_from_index = from_index
-        self._abscissa_to_index = to_index
-        # update all charts — horizontal zoom is shared across all panels
-        for chart in self._charts:
-            # update zoom window — pass None for Y to leave per-chart vertical zoom unchanged
-            chart.update_zoom_window(from_index, to_index, None, None)
+        # # calculate horizontal axis indices from the supplied ratios
+        # total = self._step_information.abscissa_to_index
+        # from_index = max(0, min(int(self._abscissa_from_index + x_left_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total - 1))
+        # to_index = max(0, min(int(self._abscissa_from_index + x_right_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total))
+        # # allow zoom-in beyond pixel width, only enforce a minimum window of 2 points
+        # min_window = 2
+        # # detect pure pan (translation) gestures: when the ratio span equals 1.0
+        # ratio_span = x_right_ratio - x_left_ratio
+        # # current window before the operation
+        # current_from = self._abscissa_from_index
+        # current_to = self._abscissa_to_index
+        # current_window = current_to - current_from
+        # # small epsilon for floating comparisons
+        # if abs(ratio_span - 1.0) < 1e-9 or zoom_factor == 1.0:
+        #     # this is a pan: compute integer shift in samples and apply
+        #     shift = int(round(x_left_ratio * current_window))
+        #     new_from = max(0, min(total - current_window, current_from + shift))
+        #     new_to = new_from + current_window
+        #     from_index = new_from
+        #     to_index = new_to
+        # else:
+        #     # choose direction based on factor (<1 zoom-in, >1 zoom-out)
+        #     window = to_index - from_index
+        #     mid = (from_index + to_index) // 2
+        #     step = max(1, window // 8)
+        #     if window < min_window:
+        #         from_index = max(0, mid - min_window // 2)
+        #         to_index = min(total, from_index + min_window)
+        #     elif zoom_factor > 1.0:
+        #         # zoom-out: expand window by a small step, up to full range
+        #         new_window = min(total, window + step)
+        #         from_index = max(0, mid - new_window // 2)
+        #         to_index = min(total, from_index + new_window)
+        #     else:
+        #         # zoom-in: reduce window by a small step, down to min_window
+        #         new_window = max(min_window, window - step)
+        #         from_index = max(0, mid - new_window // 2)
+        #         to_index = min(total, from_index + new_window)
+        # # update fields
+        # self._abscissa_from_index = from_index
+        # self._abscissa_to_index = to_index
+        # # update all charts — horizontal zoom is shared across all panels
+        # for chart in self._charts:
+        #     # update zoom window — pass None for Y to leave per-chart vertical zoom unchanged
+        #     chart.update_zoom_window(from_index, to_index, None, None)
+        ...
 
     @Slot(int, float, float)
     def _on_vertical_zoom(self, chart_index: int, y_top_ratio: float, y_bottom_ratio: float):
@@ -351,21 +349,22 @@ class MainWindow(QMainWindow):
 
     @Slot(int)
     def _on_menu_zoom_to_fit(self, chart_index: int):
-        # log information
-        logger.debug("User requested zoom to fit on chart at index: %d", chart_index)
-        # reset horizontal axis indices to show the full range of the abscissa
-        self._abscissa_from_index = self._step_information.abscissa_from_index
-        self._abscissa_to_index = self._step_information.abscissa_to_index
-        # update charts
-        for index, chart in enumerate(self._charts):
-            # check if this is the chart that triggered the zoom to fit action
-            if index == chart_index:
-                # reset zoom window
-                chart.reset_zoom_window(self._abscissa_from_index, self._abscissa_to_index, 0.0, 1.0)
-                # next
-                continue
-            # update horizontal zoom window only, keep vertical zoom as is
-            chart.update_zoom_window(self._abscissa_from_index, self._abscissa_to_index, None, None)
+        # # log information
+        # logger.debug("User requested zoom to fit on chart at index: %d", chart_index)
+        # # reset horizontal axis indices to show the full range of the abscissa
+        # self._abscissa_from_index = self._step_information.abscissa_from_index
+        # self._abscissa_to_index = self._step_information.abscissa_to_index
+        # # update charts
+        # for index, chart in enumerate(self._charts):
+        #     # check if this is the chart that triggered the zoom to fit action
+        #     if index == chart_index:
+        #         # reset zoom window
+        #         chart.reset_zoom_window(self._abscissa_from_index, self._abscissa_to_index, 0.0, 1.0)
+        #         # next
+        #         continue
+        #     # update horizontal zoom window only, keep vertical zoom as is
+        #     chart.update_zoom_window(self._abscissa_from_index, self._abscissa_to_index, None, None)
+        ...
 
     @Slot(int)
     def _on_menu_autorange(self, chart_index: int):
@@ -378,15 +377,16 @@ class MainWindow(QMainWindow):
 
     @Slot(int)
     def _on_menu_zoom_abscissa_extent(self, chart_index: int):
-        # log information
-        logger.debug("User requested zoom abscissa extent on chart at index: %d", chart_index)
-        # update fields
-        self._abscissa_from_index = self._step_information.abscissa_from_index
-        self._abscissa_to_index = self._step_information.abscissa_to_index
-        # update charts
-        for chart in self._charts:
-            # update zoom window
-            chart.reset_zoom_window(self._abscissa_from_index, self._abscissa_to_index, None, None)
+        # # log information
+        # logger.debug("User requested zoom abscissa extent on chart at index: %d", chart_index)
+        # # update fields
+        # self._abscissa_from_index = self._step_information.abscissa_from_index
+        # self._abscissa_to_index = self._step_information.abscissa_to_index
+        # # update charts
+        # for chart in self._charts:
+        #     # update zoom window
+        #     chart.reset_zoom_window(self._abscissa_from_index, self._abscissa_to_index, None, None)
+        ...
 
     @Slot(int)
     def _on_menu_add_remove_plots(self, chart_index: int):
@@ -487,127 +487,128 @@ class MainWindow(QMainWindow):
 
     @Slot(int)
     def _on_menu_fft(self, chart_index: int):
-        # log information
-        logger.debug("User requested FFT on chart at index: %d", chart_index)
-        # find chart
-        chart = self._charts[chart_index]
-        # collect real-valued ordinate expressions currently plotted on this chart
-        expressions = [v for v in chart.expressions if not v.complex and v != chart.abscissa]
-        if not expressions:
-            # log warning — no suitable expressions to transform
-            logger.warning("No suitable time-domain expressions to FFT on chart %d", chart_index)
-            # exit
-            return
-        # open FFT settings dialog
-        reference_step = min(chart.selected_steps) if chart.selected_steps else 0
-        reference_slice = self._step_information.abscissa_indices[reference_step]
-        fft_abscissa = Expression(self._abscissa.name, self._abscissa.data[reference_slice], self._abscissa.unit, self._abscissa.source, self._abscissa.variable_type)
-        dialog = FftDialog(expressions, fft_abscissa, self._abscissa_from_index, self._abscissa_to_index, self)
-        if dialog.exec() != FftDialog.DialogCode.Accepted:
-            return
-        # retrieve user selections
-        result_expressions = dialog.result_expressions
-        from_index = dialog.result_from_index
-        to_index = dialog.result_to_index
-        window = dialog.result_window
-        zero_pad = dialog.result_zero_pad
-        normalize = dialog.result_normalize
-        keep_dc = dialog.result_keep_dc
-        output = dialog.result_output
-        # number of samples per step (abscissa is already trimmed to one step)
-        step_count = self._step_information.length
-        # build FFT step slices and values for each input step independently to support variable step lengths
-        fft_step_indices: list[slice] = []
-        fft_source_steps: list[int] = []
-        frequency_chunks: list[np.ndarray] = []
-        fft_chunks: list[list[np.ndarray]] = [[] for _ in result_expressions]
-        # running index over the flattened FFT vectors
-        fft_offset = 0
-        # rows are [expr0, expr1, ..., exprN] for one step per FFT call
-        signal_count = len(result_expressions)
-        # process each source step independently to avoid assuming equal step lengths
-        for step_index in range(step_count):
-            # source step slice in flattened arrays
-            step_slice = self._step_information.abscissa_indices[step_index]
-            # number of source samples in this step
-            step_points = step_slice.stop - step_slice.start
-            # clamp global zoom bounds to this step and keep at least two samples
-            if step_points < 2:
-                continue
-            step_from_index = max(0, min(from_index, step_points - 2))
-            step_to_index = max(step_from_index + 2, min(to_index, step_points))
-            # absolute array bounds for this step's FFT window
-            source_from_index = step_slice.start + step_from_index
-            source_to_index = step_slice.start + step_to_index
-            # shared x slice for this step
-            x = self._abscissa.data[source_from_index:source_to_index]
-            # build a dense matrix for all selected expressions for this step
-            y_matrix = np.empty((signal_count, source_to_index - source_from_index))
-            # fill matrix row-by-row using contiguous slices
-            for expr_index, expression in enumerate(result_expressions):
-                y_matrix[expr_index] = expression.data[source_from_index:source_to_index]
-            try:
-                # fft internals allocate output arrays (spectrum/frequency/value matrices)
-                frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
-            except ValueError:
-                # log exception and abort
-                logger.exception("Batch FFT computation failed for chart %d step %d", chart_index, step_index)
-                # exit
-                return
-            # guard against an unexpectedly empty frequency axis
-            if len(frequencies) == 0:
-                # log error and abort when no frequencies are returned
-                logger.error("FFT computation returned an empty frequency axis for chart %d step %d", chart_index, step_index)
-                # exit
-                return
-            # append frequency bins for this step
-            frequency_chunks.append(frequencies)
-            # append source step index for later selection mapping
-            fft_source_steps.append(step_index)
-            # append per-expression FFT values for this step
-            for expr_index in range(signal_count):
-                fft_chunks[expr_index].append(fft_matrix[expr_index])
-            # store step output slice for the FFT result vectors
-            fft_step_indices.append(slice(fft_offset, fft_offset + len(frequencies)))
-            # advance output offset
-            fft_offset += len(frequencies)
-        # require at least one processed step
-        if not frequency_chunks:
-            # log warning and abort when no step had enough samples for FFT
-            logger.warning("FFT computation skipped: no step has at least 2 samples in the selected range")
-            # exit
-            return
-        fft_expressions: list[Expression] = []
-        for expr_index, expression in enumerate(result_expressions):
-            # flatten all per-step chunks for this expression into one step-major vector
-            expression_data = np.concatenate(fft_chunks[expr_index])
-            expression_unit = "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)
-            fft_expressions.append(Expression(f"FFT({expression.name.replace(' ', '')})", expression_data, expression_unit))
-        # flatten per-step frequency bins into one step-major vector
-        frequency_data = np.concatenate(frequency_chunks)
-        # create frequency expression with per-step variable lengths
-        freq_expression = Expression("Frequency", frequency_data, "Hz")
-        # build expression manager with frequency abscissa and all FFT results
-        expression_manager = ExpressionManager([freq_expression] + fft_expressions)
-        # build one «name» group per FFT expression so each gets its own chart
-        plot_suggestion = " ".join(f"\xabfft {e.name}\xbb" for e in fft_expressions)
-        # map source parameter values onto FFT steps
-        fft_step_values = [self._step_information.values[index] for index in fft_source_steps]
-        # create step information for FFT output
-        fft_step_information = StepInformation(self._step_information.keys, fft_step_values, fft_step_indices)
-        # create a synthetic QRawFile with frequency abscissa and all FFT values;
-        # steps matches the source simulation so the FFT window inherits full step coverage
-        fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT – {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, step_information=fft_step_information, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
-        # create a new MainWindow to render the FFT result using the existing infrastructure;
-        # pass the original source path so Jupyter always opens the correct .qraw file
-        fft_window = MainWindow(fft_qraw, source_qraw_path=self._qraw_path)
-        # pre-focus the FFT window on the same steps the user was viewing in the source chart
-        source_to_fft_index = {source_step: fft_step for fft_step, source_step in enumerate(fft_source_steps)}
-        fft_window._initial_selected_steps = {source_to_fft_index[source_step] for source_step in chart.selected_steps if source_step in source_to_fft_index}
-        # keep reference alive independently of the source main window
-        _register_child_window(fft_window)
-        # show the FFT result window
-        fft_window.show()
+        # # log information
+        # logger.debug("User requested FFT on chart at index: %d", chart_index)
+        # # find chart
+        # chart = self._charts[chart_index]
+        # # collect real-valued ordinate expressions currently plotted on this chart
+        # expressions = [v for v in chart.expressions if not v.complex and v != chart.abscissa]
+        # if not expressions:
+        #     # log warning — no suitable expressions to transform
+        #     logger.warning("No suitable time-domain expressions to FFT on chart %d", chart_index)
+        #     # exit
+        #     return
+        # # open FFT settings dialog
+        # reference_step = min(chart.selected_steps) if chart.selected_steps else 0
+        # reference_slice = self._step_information.abscissa_indices[reference_step]
+        # fft_abscissa = Expression(self._abscissa.name, self._abscissa.data[reference_slice], self._abscissa.unit, self._abscissa.source, self._abscissa.variable_type)
+        # dialog = FftDialog(expressions, fft_abscissa, self._abscissa_from_index, self._abscissa_to_index, self)
+        # if dialog.exec() != FftDialog.DialogCode.Accepted:
+        #     return
+        # # retrieve user selections
+        # result_expressions = dialog.result_expressions
+        # from_index = dialog.result_from_index
+        # to_index = dialog.result_to_index
+        # window = dialog.result_window
+        # zero_pad = dialog.result_zero_pad
+        # normalize = dialog.result_normalize
+        # keep_dc = dialog.result_keep_dc
+        # output = dialog.result_output
+        # # number of samples per step (abscissa is already trimmed to one step)
+        # step_count = self._step_information.length
+        # # build FFT step slices and values for each input step independently to support variable step lengths
+        # fft_step_indices: list[slice] = []
+        # fft_source_steps: list[int] = []
+        # frequency_chunks: list[np.ndarray] = []
+        # fft_chunks: list[list[np.ndarray]] = [[] for _ in result_expressions]
+        # # running index over the flattened FFT vectors
+        # fft_offset = 0
+        # # rows are [expr0, expr1, ..., exprN] for one step per FFT call
+        # signal_count = len(result_expressions)
+        # # process each source step independently to avoid assuming equal step lengths
+        # for step_index in range(step_count):
+        #     # source step slice in flattened arrays
+        #     step_slice = self._step_information.abscissa_indices[step_index]
+        #     # number of source samples in this step
+        #     step_points = step_slice.stop - step_slice.start
+        #     # clamp global zoom bounds to this step and keep at least two samples
+        #     if step_points < 2:
+        #         continue
+        #     step_from_index = max(0, min(from_index, step_points - 2))
+        #     step_to_index = max(step_from_index + 2, min(to_index, step_points))
+        #     # absolute array bounds for this step's FFT window
+        #     source_from_index = step_slice.start + step_from_index
+        #     source_to_index = step_slice.start + step_to_index
+        #     # shared x slice for this step
+        #     x = self._abscissa.data[source_from_index:source_to_index]
+        #     # build a dense matrix for all selected expressions for this step
+        #     y_matrix = np.empty((signal_count, source_to_index - source_from_index))
+        #     # fill matrix row-by-row using contiguous slices
+        #     for expr_index, expression in enumerate(result_expressions):
+        #         y_matrix[expr_index] = expression.data[source_from_index:source_to_index]
+        #     try:
+        #         # fft internals allocate output arrays (spectrum/frequency/value matrices)
+        #         frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
+        #     except ValueError:
+        #         # log exception and abort
+        #         logger.exception("Batch FFT computation failed for chart %d step %d", chart_index, step_index)
+        #         # exit
+        #         return
+        #     # guard against an unexpectedly empty frequency axis
+        #     if len(frequencies) == 0:
+        #         # log error and abort when no frequencies are returned
+        #         logger.error("FFT computation returned an empty frequency axis for chart %d step %d", chart_index, step_index)
+        #         # exit
+        #         return
+        #     # append frequency bins for this step
+        #     frequency_chunks.append(frequencies)
+        #     # append source step index for later selection mapping
+        #     fft_source_steps.append(step_index)
+        #     # append per-expression FFT values for this step
+        #     for expr_index in range(signal_count):
+        #         fft_chunks[expr_index].append(fft_matrix[expr_index])
+        #     # store step output slice for the FFT result vectors
+        #     fft_step_indices.append(slice(fft_offset, fft_offset + len(frequencies)))
+        #     # advance output offset
+        #     fft_offset += len(frequencies)
+        # # require at least one processed step
+        # if not frequency_chunks:
+        #     # log warning and abort when no step had enough samples for FFT
+        #     logger.warning("FFT computation skipped: no step has at least 2 samples in the selected range")
+        #     # exit
+        #     return
+        # fft_expressions: list[Expression] = []
+        # for expr_index, expression in enumerate(result_expressions):
+        #     # flatten all per-step chunks for this expression into one step-major vector
+        #     expression_data = np.concatenate(fft_chunks[expr_index])
+        #     expression_unit = "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)
+        #     fft_expressions.append(Expression(f"FFT({expression.name.replace(' ', '')})", expression_data, expression_unit))
+        # # flatten per-step frequency bins into one step-major vector
+        # frequency_data = np.concatenate(frequency_chunks)
+        # # create frequency expression with per-step variable lengths
+        # freq_expression = Expression("Frequency", frequency_data, "Hz")
+        # # build expression manager with frequency abscissa and all FFT results
+        # expression_manager = ExpressionManager([freq_expression] + fft_expressions)
+        # # build one «name» group per FFT expression so each gets its own chart
+        # plot_suggestion = " ".join(f"\xabfft {e.name}\xbb" for e in fft_expressions)
+        # # map source parameter values onto FFT steps
+        # fft_step_values = [self._step_information.values[index] for index in fft_source_steps]
+        # # create step information for FFT output
+        # fft_step_information = StepInformation(self._step_information.keys, fft_step_values, fft_step_indices)
+        # # create a synthetic QRawFile with frequency abscissa and all FFT values;
+        # # steps matches the source simulation so the FFT window inherits full step coverage
+        # fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT – {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, step_information=fft_step_information, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
+        # # create a new MainWindow to render the FFT result using the existing infrastructure;
+        # # pass the original source path so Jupyter always opens the correct .qraw file
+        # fft_window = MainWindow(fft_qraw, source_qraw_path=self._qraw_path)
+        # # pre-focus the FFT window on the same steps the user was viewing in the source chart
+        # source_to_fft_index = {source_step: fft_step for fft_step, source_step in enumerate(fft_source_steps)}
+        # fft_window._initial_selected_steps = {source_to_fft_index[source_step] for source_step in chart.selected_steps if source_step in source_to_fft_index}
+        # # keep reference alive independently of the source main window
+        # _register_child_window(fft_window)
+        # # show the FFT result window
+        # fft_window.show()
+        ...
 
     @Slot(int, float)
     def _on_pointer_moved(self, chart_index: int, x_ratio: float):

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -6,9 +6,10 @@ import numpy as np
 from PySide6.QtCore import QSize, QTimer, QUrl, Slot
 from PySide6.QtGui import QAction, QColor, QGuiApplication, QIcon, QKeySequence
 from PySide6.QtQuick import QQuickView
-from PySide6.QtWidgets import QMainWindow, QWidget
+from PySide6.QtWidgets import QFileDialog, QMainWindow, QWidget
 
 from .add_plot_dialog import AddPlotDialog
+from .app_open import open_qraw_as_window
 from .chart import Chart
 from .expression import Expression
 from .expression_manager import ExpressionManager
@@ -38,6 +39,9 @@ _MIN_STATUS_INTERVAL = 1.0 / 30
 # application-level registry keeps child windows alive independently
 # of the source main window that created them
 _CHILD_WINDOWS: set[QMainWindow] = set()
+
+# application-level open-file dialog lock prevents stacked dialogs
+_OPEN_FILE_DIALOG_ACTIVE = False
 
 
 def _register_child_window(window: QMainWindow) -> None:
@@ -270,6 +274,13 @@ class MainWindow(QMainWindow):
 
         # File menu
         file_menu = menu_bar.addMenu("&File")
+
+        # File | Open
+        open_action = QAction("Open...", self)
+        open_action.setShortcut(QKeySequence.Open)
+        open_action.triggered.connect(self._on_menu_open_file)
+        file_menu.addAction(open_action)
+
         # File | Quit
         quit_action = QAction("Quit", self)
         quit_action.setShortcut(QKeySequence.Quit)
@@ -490,6 +501,31 @@ class MainWindow(QMainWindow):
         logger.debug("User requested opening a new window")
         # create a new independent main window sharing the same source data and path
         new_window = MainWindow(self._qraw_file, source_qraw_path=self._qraw_path, start_empty=True)
+        # keep reference alive independently of the source main window
+        _register_child_window(new_window)
+        # show the new window
+        new_window.show()
+
+    @Slot()
+    def _on_menu_open_file(self) -> None:
+        # use application-level lock so only one open-file dialog can exist at a time
+        global _OPEN_FILE_DIALOG_ACTIVE
+        if _OPEN_FILE_DIALOG_ACTIVE:
+            return
+        _OPEN_FILE_DIALOG_ACTIVE = True
+        # prompt for a file
+        try:
+            input_path, _ = QFileDialog.getOpenFileName(self, "Open QRAW File", "", "QRAW Files (*.qraw);;All Files (*)")
+        finally:
+            _OPEN_FILE_DIALOG_ACTIVE = False
+        # exit when the user cancels the dialog
+        if not input_path:
+            return
+        # load file and create a new main window through shared open path
+        new_window = open_qraw_as_window(input_path, lambda qraw_file: MainWindow(qraw_file))
+        # exit when the file fails to load
+        if new_window is None:
+            return
         # keep reference alive independently of the source main window
         _register_child_window(new_window)
         # show the new window

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -15,7 +15,7 @@ from .expression_manager import ExpressionManager
 from .fft import FftOutput, compute_fft_many
 from .fft_dialog import FftDialog
 from .jupyter_window import JupyterWindow
-from .qraw_file import AbscissaScale, QRawFile
+from .qraw_file import AbscissaScale, QRawFile, StepInformation
 from .step_tool_dialog import StepToolDialog
 
 logger = logging.getLogger(__name__)
@@ -120,6 +120,7 @@ class MainWindow(QMainWindow):
         self._abscissa_scale = qraw_file.abscissa_scale
         self._expression_manager = qraw_file.expression_manager
         self._step_information = qraw_file.step_information
+        self._steps = self._step_information.length
         # normalize numpy scalar to built-in int for stable Qt property marshalling
         self._plot_suggestions = [] if start_empty else qraw_file.get_plot_suggestions()
         # store the simulation file path for use by the Jupyter integration
@@ -285,7 +286,7 @@ class MainWindow(QMainWindow):
     @Slot(int, float, float, float)
     def _on_horizontal_zoom(self, chart_index: int, x_left_ratio: float, x_right_ratio: float, zoom_factor: float):
         # calculate horizontal axis indices from the supplied ratios
-        total = len(self._abscissa.data)
+        total = self._step_information.abscissa_to_index
         from_index = max(0, min(int(self._abscissa_from_index + x_left_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total - 1))
         to_index = max(0, min(int(self._abscissa_from_index + x_right_ratio * (self._abscissa_to_index - self._abscissa_from_index)), total))
         # allow zoom-in beyond pixel width, only enforce a minimum window of 2 points
@@ -462,7 +463,10 @@ class MainWindow(QMainWindow):
             # exit
             return
         # open FFT settings dialog
-        dialog = FftDialog(expressions, self._abscissa, self._abscissa_from_index, self._abscissa_to_index, self)
+        reference_step = min(chart.selected_steps) if chart.selected_steps else 0
+        reference_slice = self._step_information.abscissa_indices[reference_step]
+        fft_abscissa = Expression(self._abscissa.name, self._abscissa.data[reference_slice], self._abscissa.unit, self._abscissa.source, self._abscissa.variable_type)
+        dialog = FftDialog(expressions, fft_abscissa, self._abscissa_from_index, self._abscissa_to_index, self)
         if dialog.exec() != FftDialog.DialogCode.Accepted:
             return
         # retrieve user selections
@@ -475,63 +479,95 @@ class MainWindow(QMainWindow):
         keep_dc = dialog.result_keep_dc
         output = dialog.result_output
         # number of samples per step (abscissa is already trimmed to one step)
-        step_points = len(self._abscissa.data)
-        # shared abscissa slice — identical across all steps since the abscissa is periodic
-        x = self._abscissa.data[from_index:to_index]
-        # build one batch matrix for all expressions and all steps in expression-major order;
-        # rows are [expr0-step0, expr0-step1, ..., exprN-stepS]
+        step_count = self._step_information.length
+        # build FFT step slices and values for each input step independently to support variable step lengths
+        fft_step_indices: list[slice] = []
+        fft_source_steps: list[int] = []
+        frequency_chunks: list[np.ndarray] = []
+        fft_chunks: list[list[np.ndarray]] = [[] for _ in result_expressions]
+        # running index over the flattened FFT vectors
+        fft_offset = 0
+        # rows are [expr0, expr1, ..., exprN] for one step per FFT call
         signal_count = len(result_expressions)
-        sample_count = to_index - from_index
-        # allocate dense batch buffer once; this owns the copied FFT input payload
-        y_matrix = np.empty((signal_count * self._steps, sample_count))
-        # fill each expression block with all step slices at once
-        for expr_index, expression in enumerate(result_expressions):
-            row_start = expr_index * self._steps
-            row_end = row_start + self._steps
-            # reshape + slice are view operations when source layout is step-major contiguous
-            step_matrix = expression.data.reshape(self._steps, step_points)[:, from_index:to_index]
-            # copy step block into the preallocated batch buffer
-            y_matrix[row_start:row_end] = step_matrix
-        try:
-            # fft internals allocate output arrays (spectrum/frequency/value matrices)
-            frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
-        except ValueError:
-            # log exception and abort
-            logger.exception("Batch FFT computation failed for chart %d", chart_index)
+        # process each source step independently to avoid assuming equal step lengths
+        for step_index in range(step_count):
+            # source step slice in flattened arrays
+            step_slice = self._step_information.abscissa_indices[step_index]
+            # number of source samples in this step
+            step_points = step_slice.stop - step_slice.start
+            # clamp global zoom bounds to this step and keep at least two samples
+            if step_points < 2:
+                continue
+            step_from_index = max(0, min(from_index, step_points - 2))
+            step_to_index = max(step_from_index + 2, min(to_index, step_points))
+            # absolute array bounds for this step's FFT window
+            source_from_index = step_slice.start + step_from_index
+            source_to_index = step_slice.start + step_to_index
+            # shared x slice for this step
+            x = self._abscissa.data[source_from_index:source_to_index]
+            # build a dense matrix for all selected expressions for this step
+            y_matrix = np.empty((signal_count, source_to_index - source_from_index))
+            # fill matrix row-by-row using contiguous slices
+            for expr_index, expression in enumerate(result_expressions):
+                y_matrix[expr_index] = expression.data[source_from_index:source_to_index]
+            try:
+                # fft internals allocate output arrays (spectrum/frequency/value matrices)
+                frequencies, fft_matrix = compute_fft_many(x, y_matrix, window, zero_pad, normalize, output, keep_dc)
+            except ValueError:
+                # log exception and abort
+                logger.exception("Batch FFT computation failed for chart %d step %d", chart_index, step_index)
+                # exit
+                return
+            # guard against an unexpectedly empty frequency axis
+            if len(frequencies) == 0:
+                # log error and abort when no frequencies are returned
+                logger.error("FFT computation returned an empty frequency axis for chart %d step %d", chart_index, step_index)
+                # exit
+                return
+            # append frequency bins for this step
+            frequency_chunks.append(frequencies)
+            # append source step index for later selection mapping
+            fft_source_steps.append(step_index)
+            # append per-expression FFT values for this step
+            for expr_index in range(signal_count):
+                fft_chunks[expr_index].append(fft_matrix[expr_index])
+            # store step output slice for the FFT result vectors
+            fft_step_indices.append(slice(fft_offset, fft_offset + len(frequencies)))
+            # advance output offset
+            fft_offset += len(frequencies)
+        # require at least one processed step
+        if not frequency_chunks:
+            # log warning and abort when no step had enough samples for FFT
+            logger.warning("FFT computation skipped: no step has at least 2 samples in the selected range")
             # exit
             return
-        # guard against an unexpectedly empty frequency axis
-        if len(frequencies) == 0:
-            # log error and abort when no frequencies are returned
-            logger.error("FFT computation returned an empty frequency axis for chart %d", chart_index)
-            # exit
-            return
-        # number of frequency bins produced per step
-        freq_points = len(frequencies)
-        # build FFT expressions from row slices in the batched output matrix;
-        # each expression keeps step-major contiguous layout: [step0, step1, ..., stepS]
         fft_expressions: list[Expression] = []
         for expr_index, expression in enumerate(result_expressions):
-            row_start = expr_index * self._steps
-            row_end = row_start + self._steps
-            # row slice is a view; reshape keeps a view for contiguous row blocks
-            expression_data = fft_matrix[row_start:row_end].reshape(self._steps * freq_points)
+            # flatten all per-step chunks for this expression into one step-major vector
+            expression_data = np.concatenate(fft_chunks[expr_index])
             expression_unit = "°" if output == FftOutput.PHASE else ("dB" if output == FftOutput.MAGNITUDE_DB else expression.unit)
             fft_expressions.append(Expression(f"FFT({expression.name.replace(' ', '')})", expression_data, expression_unit))
-        # create frequency expression — length matches a single step period (freq_points)
-        freq_expression = Expression("Frequency", frequencies, "Hz")
+        # flatten per-step frequency bins into one step-major vector
+        frequency_data = np.concatenate(frequency_chunks)
+        # create frequency expression with per-step variable lengths
+        freq_expression = Expression("Frequency", frequency_data, "Hz")
         # build expression manager with frequency abscissa and all FFT results
         expression_manager = ExpressionManager([freq_expression] + fft_expressions)
         # build one «name» group per FFT expression so each gets its own chart
         plot_suggestion = " ".join(f"\xabfft {e.name}\xbb" for e in fft_expressions)
+        # map source parameter values onto FFT steps
+        fft_step_values = [self._step_information.values[index] for index in fft_source_steps]
+        # create step information for FFT output
+        fft_step_information = StepInformation(self._step_information.keys, fft_step_values, fft_step_indices)
         # create a synthetic QRawFile with frequency abscissa and all FFT values;
         # steps matches the source simulation so the FFT window inherits full step coverage
-        fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT \u2013 {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, steps=self._steps, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
+        fft_qraw = QRawFile(filename=self._qraw_path, title=f"FFT – {', '.join(e.name for e in result_expressions)}", date="", plotname="FFT", complex=False, step_information=fft_step_information, abscissa=freq_expression, abscissa_scale=AbscissaScale.LINEAR, command="", plot_suggestion=plot_suggestion, expression_manager=expression_manager, chart_type="FFT")
         # create a new MainWindow to render the FFT result using the existing infrastructure;
         # pass the original source path so Jupyter always opens the correct .qraw file
         fft_window = MainWindow(fft_qraw, source_qraw_path=self._qraw_path)
         # pre-focus the FFT window on the same steps the user was viewing in the source chart
-        fft_window._initial_selected_steps = chart.selected_steps
+        source_to_fft_index = {source_step: fft_step for fft_step, source_step in enumerate(fft_source_steps)}
+        fft_window._initial_selected_steps = {source_to_fft_index[source_step] for source_step in chart.selected_steps if source_step in source_to_fft_index}
         # keep reference alive independently of the source main window
         _register_child_window(fft_window)
         # show the FFT result window
@@ -550,10 +586,8 @@ class MainWindow(QMainWindow):
             return
         # chart at index
         chart = self._charts[chart_index]
-        # compute abscissa index within the current zoom window
-        idx = chart.sample_index_at_ratio(x_ratio)
         # retrieve the stored abscissa value (may be in log space for decade/octave scales)
-        x_stored = float(self._abscissa.data[idx])
+        x_stored = chart.sample_abscissa_value_at_ratio(x_ratio)
         # convert stored value back to physical abscissa value
         if self._abscissa_scale == AbscissaScale.DECADE:
             x_actual = 10 ** x_stored

--- a/viewer/main_window.py
+++ b/viewer/main_window.py
@@ -582,7 +582,7 @@ class MainWindow(QMainWindow):
         # chart at index
         chart = self._charts[chart_index]
         # retrieve the stored abscissa value (may be in log space for decade/octave scales)
-        x_stored = chart.ratio_to_abscissa_value(x_ratio)
+        x_stored = chart.abscissa_value_at_cursor(x_ratio)
         # convert stored value back to physical abscissa value
         if self._abscissa_scale == AbscissaScale.DECADE:
             x_actual = 10 ** x_stored

--- a/viewer/main_window.qml
+++ b/viewer/main_window.qml
@@ -12,8 +12,7 @@ Item {
     property bool fftEnabled: false
     property bool stepToolEnabled: false
 
-    signal horizontalZoom(int chartIndex, real xLeftRatio, real xRightRatio, real zoomFactor)
-    signal verticalZoom(int chartIndex, real yTopRatio, real yBottomRatio)
+    signal zoomRegionSelected(int chartIndex, real x0Ratio, real y0Ratio, real x1Ratio, real y1Ratio)
     signal menuZoomToFit(int chartIndex)
     signal menuAutorange(int chartIndex)
     signal menuZoomAbscissaExtent(int chartIndex)
@@ -37,8 +36,7 @@ Item {
         property bool legendVisible: false
         readonly property real plotAreaWidth: graphsView.plotArea.width
 
-        signal horizontalZoom(real xLeftRatio, real xRightRatio, real zoomFactor)
-        signal verticalZoom(real yTopRatio, real yBottomRatio)
+        signal zoomRegionSelected(real x0Ratio, real y0Ratio, real x1Ratio, real y1Ratio)
         signal menuZoomToFit
         signal menuAutorange
         signal menuZoomAbscissaExtent
@@ -213,9 +211,29 @@ Item {
             }
 
             // last mouse X recorded during a pan drag — updated each frame so each delta is incremental
-            property real panLastX: 0
-            // last mouse Y recorded during a pan drag — updated each frame so each delta is incremental
-            property real panLastY: 0
+            property bool selectionActive: false
+            // rectangle selection start point in overlay coordinates
+            property real selectionStartX: 0
+            property real selectionStartY: 0
+            // rectangle selection current point in overlay coordinates
+            property real selectionCurrentX: 0
+            property real selectionCurrentY: 0
+
+            // clamp a pixel X to the visible plot area
+            function clampPixelX(px) {
+                // rectangle
+                var r = graphsView.plotArea;
+                // clamp and return
+                return Math.max(r.x, Math.min(r.x + r.width, px));
+            }
+
+            // clamp a pixel Y to the visible plot area
+            function clampPixelY(py) {
+                // rectangle
+                var r = graphsView.plotArea;
+                // clamp and return
+                return Math.max(r.y, Math.min(r.y + r.height, py));
+            }
 
             // map a pixel X within the overlay to a 0-1 plot-area fraction (0=left, 1=right)
             function pixelToXRatio(px) {
@@ -227,62 +245,77 @@ Item {
                 return Math.max(0, Math.min(1, ratio));
             }
 
-            // perform a horizontal zoom around a normalized centre point
-            // `center` must be in [0,1] and represents the x-position of the
-            // mouse cursor (or any other pivot) expressed as a fraction of the
-            // current visible range. `factor` is the scale factor applied to
-            // the window width (<1 zooms in, >1 zooms out).  This routine
-            // computes the new [left,right] ratios such that the value at
-            // `center` remains fixed on the screen, mimicking the behaviour of
-            // most professional plotting applications.
-            function applyXZoom(center, factor) {
-                // compute raw ratios
-                var xr1 = center - center * factor;
-                var xr2 = center + (1.0 - center) * factor;
-                // enforce non-negative left bound only; right may exceed 1 so Python
-                // can distinguish zoom-out from pan
-                if (xr1 < 0) {
-                    xr1 = 0;
-                }
-                panel.horizontalZoom(xr1, xr2, factor);
+            // map a pixel Y within the overlay to a 0-1 chart fraction (0=bottom, 1=top)
+            function pixelToYRatio(py) {
+                // rectangle
+                var r = graphsView.plotArea;
+                // compute ratio of pixel Y within the plot area in screen coordinates
+                var screenRatio = (py - r.y) / r.height;
+                // invert to chart coordinates and clamp to [0, 1]
+                return Math.max(0, Math.min(1, 1.0 - screenRatio));
             }
 
-            // left-button drag — pans the X axis left/right
+            Rectangle {
+                visible: selectionOverlay.selectionActive
+                x: Math.min(selectionOverlay.selectionStartX, selectionOverlay.selectionCurrentX)
+                y: Math.min(selectionOverlay.selectionStartY, selectionOverlay.selectionCurrentY)
+                width: Math.abs(selectionOverlay.selectionCurrentX - selectionOverlay.selectionStartX)
+                height: Math.abs(selectionOverlay.selectionCurrentY - selectionOverlay.selectionStartY)
+                color: "#2680eb33"
+                border.color: "#56a3ff"
+                border.width: 1
+                z: 1
+            }
+
+            // left-button drag — selects a rectangle and emits normalized chart percentages on release
             MouseArea {
                 anchors.fill: parent
                 acceptedButtons: Qt.LeftButton
                 // enable hover so onPositionChanged fires without a button held down
                 hoverEnabled: true
-                // show grab cursor while hovering so the interaction is discoverable
-                cursorShape: pressed ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+                // show a crosshair so rectangle selection is discoverable
+                cursorShape: Qt.CrossCursor
 
                 onPressed: mouse => {
-                    // record the starting X and Y so the first positionChanged has a valid reference
-                    selectionOverlay.panLastX = mouse.x;
-                    selectionOverlay.panLastY = mouse.y;
+                    // clamp the drag start to the visible plot area
+                    selectionOverlay.selectionStartX = selectionOverlay.clampPixelX(mouse.x);
+                    selectionOverlay.selectionStartY = selectionOverlay.clampPixelY(mouse.y);
+                    // initialize current corner from the same point
+                    selectionOverlay.selectionCurrentX = selectionOverlay.selectionStartX;
+                    selectionOverlay.selectionCurrentY = selectionOverlay.selectionStartY;
+                    // mark selection active so the overlay rectangle becomes visible
+                    selectionOverlay.selectionActive = true;
                 }
 
                 onPositionChanged: mouse => {
-                    if (pressed) {
-                        // compute how far the mouse moved as a fraction of the plot area dimensions
-                        var dx = (mouse.x - selectionOverlay.panLastX) / graphsView.plotArea.width;
-                        var dy = (mouse.y - selectionOverlay.panLastY) / graphsView.plotArea.height;
-                        // update references for the next incremental step
-                        selectionOverlay.panLastX = mouse.x;
-                        selectionOverlay.panLastY = mouse.y;
-                        // dragging right means pulling the data right — shift the horizontal window left
-                        panel.horizontalZoom(0 - dx, 1 - dx, 1);
-                        // dragging down in screen space means pulling the data down — shift the vertical window up
-                        // screen Y is inverted vs data Y so the sign is opposite to horizontal
-                        panel.verticalZoom(dy, 1 + dy);
+                    // only update the selection rectangle during an active drag to avoid jitter while hovering
+                    if (selectionOverlay.selectionActive) {
+                        // clamp the drag end to the visible plot area
+                        selectionOverlay.selectionCurrentX = selectionOverlay.clampPixelX(mouse.x);
+                        selectionOverlay.selectionCurrentY = selectionOverlay.clampPixelY(mouse.y);
+                        // exit
+                        return;
                     }
                     // always report pointer position to the status bar
                     panel.pointerMoved(selectionOverlay.pixelToXRatio(mouse.x));
                 }
 
+                onReleased: mouse => {
+                    // clamp the drag end before computing normalized coordinates
+                    var endX = selectionOverlay.clampPixelX(mouse.x);
+                    var endY = selectionOverlay.clampPixelY(mouse.y);
+                    // only emit when we have a valid rectangle to avoid spurious events from clicks or tiny drags
+                    if (Math.abs(endX - selectionOverlay.selectionStartX) >= 10 && Math.abs(endY - selectionOverlay.selectionStartY) >= 10) {
+                        // emit rectangle corners as normalized chart-space percentages
+                        panel.zoomRegionSelected(selectionOverlay.pixelToXRatio(selectionOverlay.selectionStartX), selectionOverlay.pixelToYRatio(selectionOverlay.selectionStartY), selectionOverlay.pixelToXRatio(endX), selectionOverlay.pixelToYRatio(endY));
+                    }
+                    // hide the selection rectangle after completion
+                    selectionOverlay.selectionActive = false;
+                }
+
                 onExited: panel.pointerExited()
 
-                onDoubleClicked: panel.menuAutorange()
+                onCanceled: selectionOverlay.selectionActive = false
             }
 
             // right-button click — asks root to open the shared context menu at this location
@@ -290,38 +323,6 @@ Item {
                 anchors.fill: parent
                 acceptedButtons: Qt.RightButton
                 onClicked: mouse => panel.menuOpenRequested(mouse.x, mouse.y, panel.seriesCount)
-            }
-
-            // mouse-wheel — X zoom toward cursor (plain), Y zoom toward cursor (Alt held)
-            WheelHandler {
-                // include TouchPad so macOS trackpads are handled as well
-                acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
-                onWheel: function (event) {
-                    // zoom factor: <1 = zoom in, >1 = zoom out; 0.15 per standard detent
-                    // log raw wheel movement
-
-                    // compute factor: positive delta will now produce f>1 (zoom out)
-                    var f = 1.0 + (event.angleDelta.y / 120) * 0.15;
-                    // clamp to avoid inverting the range or zooming out infinitely
-                    f = Math.max(0.05, Math.min(4.0, f));
-                    if (event.modifiers & Qt.AltModifier) {
-                        // vertical zoom centered on cursor Y position
-                        var r = graphsView.plotArea;
-                        // cursor as 0-1 fraction of plot height in screen space (0=top, 1=bottom)
-                        var cy_screen = Math.max(0, Math.min(1, (event.y - r.y) / r.height));
-                        // invert to data space so 0=bottom of range, 1=top of range
-                        var cy = 1.0 - cy_screen;
-                        var yr1 = cy - cy * f;
-                        var yr2 = cy + (1.0 - cy) * f;
-                        // emit dedicated vertical signal so it never collides with horizontal ratios
-                        panel.verticalZoom(yr1, yr2);
-                    } else {
-                        // horizontal zoom centered on cursor X position
-                        var cx = selectionOverlay.pixelToXRatio(event.x);
-                        // call helper on the overlay object so it’s in scope
-                        selectionOverlay.applyXZoom(cx, f);
-                    }
-                }
             }
         }
 
@@ -524,8 +525,7 @@ Item {
                 // distribute height equally, accounting for inter-panel spacing
                 height: (chartsColumn.height - chartsColumn.spacing * Math.max(0, chartsModel.count - 1)) / Math.max(1, chartsModel.count)
 
-                onHorizontalZoom: (xr1, xr2, f) => root.horizontalZoom(index, xr1, xr2, f)
-                onVerticalZoom: (yr1, yr2) => root.verticalZoom(index, yr1, yr2)
+                onZoomRegionSelected: (x0, y0, x1, y1) => root.zoomRegionSelected(index, x0, y0, x1, y1)
                 // bubble menu action signals up to root, adding chartIndex
                 onMenuZoomToFit: root.menuZoomToFit(index)
                 onMenuAutorange: root.menuAutorange(index)

--- a/viewer/main_window.qml
+++ b/viewer/main_window.qml
@@ -140,33 +140,33 @@ Item {
                 const absValue = Math.abs(value);
                 // giga
                 if (absValue >= 1e9)
-                    return (value / 1e9).toFixed(1) + "G" + unit;
+                    return (value / 1e9).toFixed(1) + " G" + unit;
                 // mega
                 if (absValue >= 1e6)
-                    return (value / 1e6).toFixed(1) + "M" + unit;
+                    return (value / 1e6).toFixed(1) + " M" + unit;
                 // kilo
                 if (absValue >= 1e3)
-                    return (value / 1e3).toFixed(1) + "k" + unit;
+                    return (value / 1e3).toFixed(1) + " k" + unit;
                 // base unit
                 if (absValue >= 1.0)
-                    return value.toFixed(1) + unit;
+                    return value.toFixed(1) + " " + unit;
                 // zero
                 if (absValue < 1e-15)
                     return "0" + unit;
                 // femto
                 if (absValue < 1e-12)
-                    return (value * 1e15).toFixed(1) + "f" + unit;
+                    return (value * 1e15).toFixed(1) + " f" + unit;
                 // pico
                 if (absValue < 1e-9)
-                    return (value * 1e12).toFixed(1) + "p" + unit;
+                    return (value * 1e12).toFixed(1) + " p" + unit;
                 // nano
                 if (absValue < 1e-6)
-                    return (value * 1e9).toFixed(1) + "n" + unit;
+                    return (value * 1e9).toFixed(1) + " n" + unit;
                 // micro
                 if (absValue < 1e-3)
-                    return (value * 1e6).toFixed(1) + "µ" + unit;
+                    return (value * 1e6).toFixed(1) + " µ" + unit;
                 // milli
-                return (value * 1e3).toFixed(1) + "m" + unit;
+                return (value * 1e3).toFixed(1) + " m" + unit;
             }
 
             function linearValueFormatter(unit, text) {

--- a/viewer/qraw_file.py
+++ b/viewer/qraw_file.py
@@ -68,11 +68,19 @@ class StepInformation:
         self._values = values
         self._abscissa_indices = abscissa_indices
         self._abscissa_value_ranges = abscissa_value_ranges
-        # calculated values for quick lookup
+        # number of steps
         self._step_count = len(abscissa_indices)
-        self._abscissa_left_value = min((min(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
-        self._abscissa_right_value = max((max(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
-        self._abscissa_ascending = self._abscissa_left_value <= self._abscissa_right_value
+        # determine if abscissa is ascending or descending based on the first step's abscissa value range
+        self._abscissa_ascending = self._abscissa_value_ranges[0][0] <= self._abscissa_value_ranges[0][1] if len(self._abscissa_value_ranges) > 0 else True
+        # check abscissa direction
+        if self._abscissa_ascending:
+            # left and right values
+            self._abscissa_left_value = float(min((value_range[0] for value_range in self._abscissa_value_ranges), default=0.0))
+            self._abscissa_right_value = float(max((value_range[1] for value_range in self._abscissa_value_ranges), default=0.0))
+        else:
+            # left and right values
+            self._abscissa_left_value = float(max((value_range[0] for value_range in self._abscissa_value_ranges), default=0.0))
+            self._abscissa_right_value = float(min((value_range[1] for value_range in self._abscissa_value_ranges), default=0.0))
 
     @property
     def keys(self) -> list[str]:

--- a/viewer/qraw_file.py
+++ b/viewer/qraw_file.py
@@ -62,16 +62,17 @@ class PlotSuggestion:
 
 class StepInformation:
 
-    def __init__(self, keys: list[str], values: list[tuple], abscissa_indices: list[slice]):
+    def __init__(self, keys: list[str], values: list[tuple], abscissa_indices: list[slice], step_lengths: list[int], abscissa_value_ranges: list[tuple[float, float]]):
         # fields
         self._keys = keys
         self._values = values
         self._abscissa_indices = abscissa_indices
+        self._step_lengths = step_lengths
+        self._abscissa_value_ranges = abscissa_value_ranges
         # calculated values for quick lookup
         self._step_count = len(abscissa_indices)
-        self._step_lengths = [step_indices.stop - step_indices.start for step_indices in self._abscissa_indices]
-        self._abscissa_from_index = 0
-        self._abscissa_to_index = int(max(self._step_lengths, default=0))
+        self._abscissa_from_value = min((min(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
+        self._abscissa_to_value = max((max(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
 
     @property
     def keys(self) -> list[str]:
@@ -90,20 +91,35 @@ class StepInformation:
         return self._step_count
 
     @property
-    def abscissa_from_index(self) -> int:
-        return self._abscissa_from_index
+    def abscissa_from_value(self) -> float:
+        return self._abscissa_from_value
 
     @property
-    def abscissa_to_index(self) -> int:
-        return self._abscissa_to_index
+    def abscissa_to_value(self) -> float:
+        return self._abscissa_to_value
 
     def step_length(self, step_index: int) -> int:
         return self._step_lengths[step_index]
 
+    def step_abscissa_from_value(self, step_index: int) -> float:
+        return self._abscissa_value_ranges[step_index][0]
 
-def _process_steps(expressions: list[Expression], num_points: int) -> StepInformation:
+    def step_abscissa_to_value(self, step_index: int) -> float:
+        return self._abscissa_value_ranges[step_index][1]
+
+
+def _process_steps(stepped: bool, expressions: list[Expression], abscissa: Expression, num_points: int) -> StepInformation:
+    # check this is a stepped analysis
+    if not stepped:
+        # not a stepped analysis — return a single step covering the entire abscissa range with no parameter values
+        return StepInformation(keys=[], values=[], abscissa_indices=[slice(0, num_points)], step_lengths=[num_points], abscissa_value_ranges=[(float(abscissa.data[0]), float(abscissa.data[-1]))] if num_points > 0 else [(0.0, 0.0)])
+    # parameter expressions
+    parameters = [expr for expr in expressions if expr.variable_type == "parameter"]
+    if len(parameters) == 0:
+        # treat as unstepped
+        return StepInformation(keys=[], values=[], abscissa_indices=[slice(0, num_points)], step_lengths=[num_points], abscissa_value_ranges=[(float(abscissa.data[0]), float(abscissa.data[-1]))] if num_points > 0 else [(0.0, 0.0)])
     # stack all parameter values into a matrix (num_points, num_parameters)
-    stacked = np.column_stack([expr.data for expr in expressions])
+    stacked = np.column_stack([expression.data for expression in parameters]) if len(parameters) > 1 else parameters[0].data.reshape(-1, 1)
     # detect changes in parameter values (N - 1, )
     changed = np.any(stacked[1:] != stacked[:-1], axis=1)
     # boundaries
@@ -111,10 +127,21 @@ def _process_steps(expressions: list[Expression], num_points: int) -> StepInform
     # start and end indices of each step
     starts = np.concatenate(([0], boundaries))
     ends = np.concatenate((boundaries, [num_points]))
+    # convert to Python int lists for performance — .tolist() converts numpy array to native Python list, avoiding np.int64 scalars in slice operations and step_lengths
+    starts_list = starts.astype(int, copy=False).tolist()
+    ends_list = ends.astype(int, copy=False).tolist()
     # parameter values at the start of each step
-    values = [tuple(stacked[s].tolist()) for s in starts]
+    values = [tuple(stacked[int(s)].tolist()) for s in starts_list]
+    # calculate slices for each one of the steps
+    abscissa_indices = [slice(s, e) for s, e in zip(starts_list, ends_list)]
+    # per-step abscissa value ranges in display space
+    abscissa_value_ranges = [(float(abscissa.data[step_slice.start]), float(abscissa.data[step_slice.stop - 1])) for step_slice in abscissa_indices]
+    # step lengths
+    step_lengths = [e - s for e, s in zip(ends_list, starts_list)]
+    # log step information
+    logger.debug("Detected %d steps in data, step lengths: %s", len(starts), step_lengths)
     # create step information object
-    return StepInformation(keys=[expr.name for expr in expressions], values=values, abscissa_indices=[slice(int(s), int(e)) for s, e in zip(starts, ends)])
+    return StepInformation(keys=[expression.name for expression in parameters], values=values, abscissa_indices=abscissa_indices, step_lengths=step_lengths, abscissa_value_ranges=abscissa_value_ranges)
 
 
 def _process_scale(abscissa: Expression, scale: AbscissaScale) -> Expression:
@@ -189,9 +216,6 @@ class QRawFile:
     @property
     def steps(self) -> int:
         return self._step_information.length
-
-    def step_length(self, step_index: int) -> int:
-        return self._step_information.step_length(step_index)
 
     @property
     def abscissa(self) -> Expression:
@@ -392,10 +416,10 @@ class QRawFile:
                     except Exception as ex:
                         # log error but continue processing other aliasses
                         logger.error("Failed to evaluate expression '%s': %s", alias_name, ex)
-            # process steps in stepped files
-            step_information = _process_steps([expr for expr in variables if expr.variable_type == "parameter"], num_points) if stepped else StepInformation(keys=[], values=[tuple()], abscissa_indices=[slice(0, num_points)])
             # process scale (x axis)
             abscissa = _process_scale(variables[0], abscissa_scale)
+            # process steps in stepped files using the scaled abscissa values
+            step_information = _process_steps(stepped, variables, abscissa, num_points)
             # create QRawFile instance with parsed header, variables, and binary data; pass the mmap so it stays alive for the lifetime of the QRawFile — Variable arrays are views into it
             return QRawFile(filename=path, title=header.get("Title", ""), date=header.get("Date", ""), plotname=header.get("Plotname", ""), complex=complex, step_information=step_information, abscissa=abscissa, abscissa_scale=abscissa_scale, command=header.get("Command", ""), plot_suggestion=header.get("Plot Suggestion(s)", ""), expression_manager=expression_manager, _mmap=data)
         finally:

--- a/viewer/qraw_file.py
+++ b/viewer/qraw_file.py
@@ -105,7 +105,7 @@ class StepInformation:
     @property
     def abscissa_right_value(self) -> float:
         return self._abscissa_right_value
-    
+
     @property
     def abscissa_ascending(self) -> bool:
         return self._abscissa_ascending

--- a/viewer/qraw_file.py
+++ b/viewer/qraw_file.py
@@ -58,7 +58,7 @@ class PlotSuggestion:
     @property
     def expressions(self) -> list[Expression]:
         return self._expressions
-    
+
 
 class StepInformation:
 
@@ -69,13 +69,14 @@ class StepInformation:
         self._abscissa_indices = abscissa_indices
         # calculated values for quick lookup
         self._step_count = len(abscissa_indices)
+        self._step_lengths = [step_indices.stop - step_indices.start for step_indices in self._abscissa_indices]
         self._abscissa_from_index = 0
-        self._abscissa_to_index = np.min([step_indices.stop - step_indices.start for step_indices in self._abscissa_indices])
+        self._abscissa_to_index = int(max(self._step_lengths, default=0))
 
     @property
     def keys(self) -> list[str]:
         return self._keys
-    
+
     @property
     def values(self) -> list[tuple]:
         return self._values
@@ -91,10 +92,13 @@ class StepInformation:
     @property
     def abscissa_from_index(self) -> int:
         return self._abscissa_from_index
-    
+
     @property
     def abscissa_to_index(self) -> int:
         return self._abscissa_to_index
+
+    def step_length(self, step_index: int) -> int:
+        return self._step_lengths[step_index]
 
 
 def _process_steps(expressions: list[Expression], num_points: int) -> StepInformation:
@@ -181,6 +185,13 @@ class QRawFile:
     @property
     def step_information(self) -> StepInformation:
         return self._step_information
+
+    @property
+    def steps(self) -> int:
+        return self._step_information.length
+
+    def step_length(self, step_index: int) -> int:
+        return self._step_information.step_length(step_index)
 
     @property
     def abscissa(self) -> Expression:
@@ -382,7 +393,7 @@ class QRawFile:
                         # log error but continue processing other aliasses
                         logger.error("Failed to evaluate expression '%s': %s", alias_name, ex)
             # process steps in stepped files
-            step_information = _process_steps([expr for expr in variables if expr.variable_type == "parameter"], num_points) if stepped else StepInformation(keys=[], values=[], indices=[slice(0, num_points)])
+            step_information = _process_steps([expr for expr in variables if expr.variable_type == "parameter"], num_points) if stepped else StepInformation(keys=[], values=[tuple()], abscissa_indices=[slice(0, num_points)])
             # process scale (x axis)
             abscissa = _process_scale(variables[0], abscissa_scale)
             # create QRawFile instance with parsed header, variables, and binary data; pass the mmap so it stays alive for the lifetime of the QRawFile — Variable arrays are views into it

--- a/viewer/qraw_file.py
+++ b/viewer/qraw_file.py
@@ -62,17 +62,17 @@ class PlotSuggestion:
 
 class StepInformation:
 
-    def __init__(self, keys: list[str], values: list[tuple], abscissa_indices: list[slice], step_lengths: list[int], abscissa_value_ranges: list[tuple[float, float]]):
+    def __init__(self, keys: list[str], values: list[tuple], abscissa_indices: list[slice], abscissa_value_ranges: list[tuple[float, float]]):
         # fields
         self._keys = keys
         self._values = values
         self._abscissa_indices = abscissa_indices
-        self._step_lengths = step_lengths
         self._abscissa_value_ranges = abscissa_value_ranges
         # calculated values for quick lookup
         self._step_count = len(abscissa_indices)
-        self._abscissa_from_value = min((min(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
-        self._abscissa_to_value = max((max(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
+        self._abscissa_left_value = min((min(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
+        self._abscissa_right_value = max((max(value_range) for value_range in self._abscissa_value_ranges), default=0.0)
+        self._abscissa_ascending = self._abscissa_left_value <= self._abscissa_right_value
 
     @property
     def keys(self) -> list[str]:
@@ -91,20 +91,21 @@ class StepInformation:
         return self._step_count
 
     @property
-    def abscissa_from_value(self) -> float:
-        return self._abscissa_from_value
+    def abscissa_left_value(self) -> float:
+        return self._abscissa_left_value
 
     @property
-    def abscissa_to_value(self) -> float:
-        return self._abscissa_to_value
+    def abscissa_right_value(self) -> float:
+        return self._abscissa_right_value
+    
+    @property
+    def abscissa_ascending(self) -> bool:
+        return self._abscissa_ascending
 
-    def step_length(self, step_index: int) -> int:
-        return self._step_lengths[step_index]
-
-    def step_abscissa_from_value(self, step_index: int) -> float:
+    def step_abscissa_left_value(self, step_index: int) -> float:
         return self._abscissa_value_ranges[step_index][0]
 
-    def step_abscissa_to_value(self, step_index: int) -> float:
+    def step_abscissa_right_value(self, step_index: int) -> float:
         return self._abscissa_value_ranges[step_index][1]
 
 
@@ -112,12 +113,12 @@ def _process_steps(stepped: bool, expressions: list[Expression], abscissa: Expre
     # check this is a stepped analysis
     if not stepped:
         # not a stepped analysis — return a single step covering the entire abscissa range with no parameter values
-        return StepInformation(keys=[], values=[], abscissa_indices=[slice(0, num_points)], step_lengths=[num_points], abscissa_value_ranges=[(float(abscissa.data[0]), float(abscissa.data[-1]))] if num_points > 0 else [(0.0, 0.0)])
+        return StepInformation(keys=[], values=[], abscissa_indices=[slice(0, num_points)], abscissa_value_ranges=[(float(abscissa.data[0]), float(abscissa.data[-1]))] if num_points > 0 else [(0.0, 0.0)])
     # parameter expressions
     parameters = [expr for expr in expressions if expr.variable_type == "parameter"]
     if len(parameters) == 0:
         # treat as unstepped
-        return StepInformation(keys=[], values=[], abscissa_indices=[slice(0, num_points)], step_lengths=[num_points], abscissa_value_ranges=[(float(abscissa.data[0]), float(abscissa.data[-1]))] if num_points > 0 else [(0.0, 0.0)])
+        return StepInformation(keys=[], values=[], abscissa_indices=[slice(0, num_points)], abscissa_value_ranges=[(float(abscissa.data[0]), float(abscissa.data[-1]))] if num_points > 0 else [(0.0, 0.0)])
     # stack all parameter values into a matrix (num_points, num_parameters)
     stacked = np.column_stack([expression.data for expression in parameters]) if len(parameters) > 1 else parameters[0].data.reshape(-1, 1)
     # detect changes in parameter values (N - 1, )
@@ -136,12 +137,8 @@ def _process_steps(stepped: bool, expressions: list[Expression], abscissa: Expre
     abscissa_indices = [slice(s, e) for s, e in zip(starts_list, ends_list)]
     # per-step abscissa value ranges in display space
     abscissa_value_ranges = [(float(abscissa.data[step_slice.start]), float(abscissa.data[step_slice.stop - 1])) for step_slice in abscissa_indices]
-    # step lengths
-    step_lengths = [e - s for e, s in zip(ends_list, starts_list)]
-    # log step information
-    logger.debug("Detected %d steps in data, step lengths: %s", len(starts), step_lengths)
     # create step information object
-    return StepInformation(keys=[expression.name for expression in parameters], values=values, abscissa_indices=abscissa_indices, step_lengths=step_lengths, abscissa_value_ranges=abscissa_value_ranges)
+    return StepInformation(keys=[expression.name for expression in parameters], values=values, abscissa_indices=abscissa_indices, abscissa_value_ranges=abscissa_value_ranges)
 
 
 def _process_scale(abscissa: Expression, scale: AbscissaScale) -> Expression:


### PR DESCRIPTION
## Summary
- refactor stepped simulation handling to support variable-length abscissa per step
- redesign FFT batching to avoid equal-length step reshape assumptions
- make horizontal zoom and chart slicing step-aware
- keep ndarray-heavy paths performance-oriented

## Validation
- flake8 viewer/qraw_file.py viewer/chart.py viewer/main_window.py
- python -m viewer test.qraw --headless
